### PR TITLE
Enable the four custom instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install: $(ISASIM_H) $(ISASIM_HWACHA_H) $(PK_H) $(ENV_H) $(GAS_H) $(XCC_H) inst.
 
 $(ISASIM_H) $(PK_H) $(ENV_H): $(ALL_OPCODES) parse-opcodes
 	cp encoding.h $@
-	cat opcodes | ./parse-opcodes -c >> $@
+	cat opcodes opcodes-custom | ./parse-opcodes -c >> $@
 
 $(GAS_H) $(XCC_H): $(ALL_OPCODES) parse-opcodes
 	cat $(ALL_OPCODES) | ./parse-opcodes -c > $@


### PR DESCRIPTION
I'd like to experiment with custom instructions in riscv-isa-sim, so I have a few patches to enable the four custom instructions. This is the first patch of the group.

This patch is a Makefile tweak for riscv-opcodes so that the custom instructions get added to encoding.h in the following components:
- riscv-isa-sim
- riscv-pk
- riscv-test-env
