### PR TITLE
Make the hashbang portable

### DIFF
--- a/parse-opcodes
+++ b/parse-opcodes
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import math
 import sys


### PR DESCRIPTION
Not all systems put Python binary in /usr/bin; fix it as usual by using env(1)