### PR TITLE
Updated path to FESVR_H in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/sh
 
 ISASIM_H := ../riscv-isa-sim/riscv/encoding.h
 PK_H := ../riscv-pk/machine/encoding.h
-FESVR_H := ../riscv-fesvr/fesvr/encoding.h
+FESVR_H := ../riscv-isa-sim/fesvr/encoding.h
 ENV_H := ../riscv-tests/env/encoding.h
 OPENOCD_H := ../riscv-openocd/src/target/riscv/encoding.h
 


### PR DESCRIPTION
Fixed the Makefile again after it was broken in this commit: https://github.com/riscv/riscv-tools/commit/1d08559a0280a0b975381ea4a0591ecd9ee56059