### PR TITLE
rvv: opcode: fix encoding oversight

### DIFF
--- a/opcodes-rvv
+++ b/opcodes-rvv
@@ -82,13 +82,12 @@ vfmax.vf       31..26=0x06 vm vs2 rs1 14..12=0x5 vd 6..0=0x57
 vfsgnj.vf      31..26=0x08 vm vs2 rs1 14..12=0x5 vd 6..0=0x57
 vfsgnjn.vf     31..26=0x09 vm vs2 rs1 14..12=0x5 vd 6..0=0x57
 vfsgnjx.vf     31..26=0x0a vm vs2 rs1 14..12=0x5 vd 6..0=0x57
-vfmv.s.f       31..26=0x0d 25=1 24..20=0 rs1      14..12=0x5 vd 6..0=0x57
+vfmv.s.f       31..26=0x10 25=1 24..20=0 rs1 14..12=0x5 vd 6..0=0x57
 
 vfmerge.vfm    31..26=0x17 25=0 vs2 rs1 14..12=0x5 vd 6..0=0x57
 vfmv.v.f       31..26=0x17 25=1 24..20=0 rs1 14..12=0x5 vd 6..0=0x57
 vmfeq.vf       31..26=0x18 vm vs2 rs1 14..12=0x5 vd 6..0=0x57
 vmfle.vf       31..26=0x19 vm vs2 rs1 14..12=0x5 vd 6..0=0x57
-vmford.vf      31..26=0x1a vm vs2 rs1 14..12=0x5 vd 6..0=0x57
 vmflt.vf       31..26=0x1b vm vs2 rs1 14..12=0x5 vd 6..0=0x57
 vmfne.vf       31..26=0x1c vm vs2 rs1 14..12=0x5 vd 6..0=0x57
 vmfgt.vf       31..26=0x1d vm vs2 rs1 14..12=0x5 vd 6..0=0x57
@@ -129,11 +128,10 @@ vfredmax.vs    31..26=0x07 vm vs2 vs1 14..12=0x1 vd 6..0=0x57
 vfsgnj.vv      31..26=0x08 vm vs2 vs1 14..12=0x1 vd 6..0=0x57
 vfsgnjn.vv     31..26=0x09 vm vs2 vs1 14..12=0x1 vd 6..0=0x57
 vfsgnjx.vv     31..26=0x0a vm vs2 vs1 14..12=0x1 vd 6..0=0x57
-vfmv.f.s       31..26=0x0c 25=1 vs2      19..15=0 14..12=0x1 rd 6..0=0x57
+vfmv.f.s       31..26=0x10 25=1 vs2 19..15=0 14..12=0x1 rd 6..0=0x57
 
 vmfeq.vv       31..26=0x18 vm vs2 vs1 14..12=0x1 vd 6..0=0x57
 vmfle.vv       31..26=0x19 vm vs2 vs1 14..12=0x1 vd 6..0=0x57
-vmford.vv      31..26=0x1a vm vs2 vs1 14..12=0x1 vd 6..0=0x57
 vmflt.vv       31..26=0x1b vm vs2 vs1 14..12=0x1 vd 6..0=0x57
 vmfne.vv       31..26=0x1c vm vs2 vs1 14..12=0x1 vd 6..0=0x57
 
@@ -326,7 +324,7 @@ vredminu.vs    31..26=0x04 vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 vredmin.vs     31..26=0x05 vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 vredmaxu.vs    31..26=0x06 vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 vredmax.vs     31..26=0x07 vm vs2 vs1 14..12=0x2 vd 6..0=0x57
-vmv.x.s        31..26=0x0c 25=1 vs2 19..15=0 14..12=0x2 vd 6..0=0x57
+vmv.x.s        31..26=0x10 25=1 vs2 19..15=0 14..12=0x2 vd 6..0=0x57
 
 vcompress.vm   31..26=0x17 vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 vmandnot.mm    31..26=0x18 vm vs2 vs1 14..12=0x2 vd 6..0=0x57
@@ -338,13 +336,13 @@ vmnand.mm      31..26=0x1d vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 vmnor.mm       31..26=0x1e vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 vmxnor.mm      31..26=0x1f vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 
-vmsbf.m        31..26=0x16 vm vs2 19..15=0x01 14..12=0x2 vd 6..0=0x57
-vmsof.m        31..26=0x16 vm vs2 19..15=0x02 14..12=0x2 vd 6..0=0x57
-vmsif.m        31..26=0x16 vm vs2 19..15=0x03 14..12=0x2 vd 6..0=0x57
-viota.m        31..26=0x16 vm vs2 19..15=0x10 14..12=0x2 vd 6..0=0x57
-vid.v          31..26=0x16 vm 24..20=0 19..15=0x11 14..12=0x2 vd 6..0=0x57
-vpopc.m        31..26=0x16 vm vs2 19..15=0x18 14..12=0x2 rd 6..0=0x57
-vfirst.m       31..26=0x16 vm vs2 19..15=0x19 14..12=0x2 rd 6..0=0x57
+vmsbf.m        31..26=0x14 vm vs2 19..15=0x01 14..12=0x2 vd 6..0=0x57
+vmsof.m        31..26=0x14 vm vs2 19..15=0x02 14..12=0x2 vd 6..0=0x57
+vmsif.m        31..26=0x14 vm vs2 19..15=0x03 14..12=0x2 vd 6..0=0x57
+viota.m        31..26=0x14 vm vs2 19..15=0x10 14..12=0x2 vd 6..0=0x57
+vid.v          31..26=0x14 vm 24..20=0 19..15=0x11 14..12=0x2 vd 6..0=0x57
+vpopc.m        31..26=0x10 vm vs2 19..15=0x10 14..12=0x2 rd 6..0=0x57
+vfirst.m       31..26=0x10 vm vs2 19..15=0x11 14..12=0x2 rd 6..0=0x57
 
 vdivu.vv       31..26=0x20 vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 vdiv.vv        31..26=0x21 vm vs2 vs1 14..12=0x2 vd 6..0=0x57
@@ -375,7 +373,7 @@ vwmacc.vv      31..26=0x3d vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 vwmaccsu.vv    31..26=0x3e vm vs2 vs1 14..12=0x2 vd 6..0=0x57
 
 # OPMVX
-vmv.s.x        31..26=0x0d 25=1 24..20=0 rs1 14..12=0x6 vd 6..0=0x57
+vmv.s.x        31..26=0x10 25=1 24..20=0 rs1 14..12=0x6 vd 6..0=0x57
 vslide1up.vx   31..26=0x0e vm vs2 rs1 14..12=0x6 vd 6..0=0x57
 vslide1down.vx 31..26=0x0f vm vs2 rs1 14..12=0x6 vd 6..0=0x57
 


### PR DESCRIPTION
With the latest RVV opcode
https://github.com/riscv/riscv-v-spec/blob/master/inst-table.adoc

* Two instructions were removed.
* Both encoding VWXUNARY0 and VRXUNARY0 were added.
* The encoding VMUNARY0 was updated.