### PR TITLE
Using OrderedDict to keep encodings for match/mask.

### DIFF
--- a/parse_opcodes
+++ b/parse_opcodes
@@ -6,10 +6,11 @@ from builtins import range
 import math
 import sys
 import tokenize
+from collections import OrderedDict
 
 namelist = []
-match = {}
-mask = {}
+match = OrderedDict()
+mask = OrderedDict()
 pseudos = {}
 arguments = {}
 


### PR DESCRIPTION
The purpose of this patch is prevent got different result in different python env.

I got lots unnecessary diff during updating encoding.h in riscv-pk, lots diff are just in different order,  and I realized the problem is cause by the dict type didn't guarantee the order when traversal items, so OrderedDict can prevent this problem in future I think.