### PR TITLE
Force bit 25 zero for RV32I

### DIFF
--- a/opcodes-rv32i
+++ b/opcodes-rv32i
@@ -22,12 +22,12 @@ lui     rd imm20 6..2=0x0D 1..0=3
 auipc   rd imm20 6..2=0x05 1..0=3
 
 addi    rd rs1 imm12           14..12=0 6..2=0x04 1..0=3
-slli    rd rs1 31..26=0  shamt 14..12=1 6..2=0x04 1..0=3
+slli    rd rs1 31..25=0  shamt 14..12=1 6..2=0x04 1..0=3
 slti    rd rs1 imm12           14..12=2 6..2=0x04 1..0=3
 sltiu   rd rs1 imm12           14..12=3 6..2=0x04 1..0=3
 xori    rd rs1 imm12           14..12=4 6..2=0x04 1..0=3
-srli    rd rs1 31..26=0  shamt 14..12=5 6..2=0x04 1..0=3
-srai    rd rs1 31..26=16 shamt 14..12=5 6..2=0x04 1..0=3
+srli    rd rs1 31..25=0  shamt 14..12=5 6..2=0x04 1..0=3
+srai    rd rs1 31..25=32 shamt 14..12=5 6..2=0x04 1..0=3
 ori     rd rs1 imm12           14..12=6 6..2=0x04 1..0=3
 andi    rd rs1 imm12           14..12=7 6..2=0x04 1..0=3
 


### PR DESCRIPTION
As in Section 2.4 of the unprivileged specification ([20191213](https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMAFDQC/riscv-spec-20191213.pdf)), `shamt` of immediate shift instructions should occupy the same bit range as `rs2` in register-only instructions, to have fixed value of either `0b0000000` or `0b0100000` in the most significant 7 bits. While in the opcode description in this repository, the value of bit 25 was not enforced. Is there an specific reason to have such discrepancy?

https://github.com/riscv/riscv-opcodes/blob/03be826f17faedcaee7f60223f402850e254df0a/opcodes-rv32i#L30