### PR TITLE
scalar-crypto: Add opcodes for RV32K, RV64K

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PK_H := ../riscv-pk/machine/encoding.h
 ENV_H := ../riscv-tests/env/encoding.h
 OPENOCD_H := ../riscv-openocd/src/target/riscv/encoding.h
 
-ALL_REAL_ILEN32_OPCODES := opcodes-rv32i opcodes-rv64i opcodes-rv32m opcodes-rv64m opcodes-rv32a opcodes-rv64a opcodes-rv32h opcodes-rv64h opcodes-rv32f opcodes-rv64f opcodes-rv32d opcodes-rv64d opcodes-rv32q opcodes-rv64q opcodes-rv32b opcodes-rv64b opcodes-system opcodes-rv32zfh opcodes-rv32d-zfh opcodes-rv32q-zfh opcodes-rv64zfh
+ALL_REAL_ILEN32_OPCODES := opcodes-rv32i opcodes-rv64i opcodes-rv32m opcodes-rv64m opcodes-rv32a opcodes-rv64a opcodes-rv32h opcodes-rv64h opcodes-rv32f opcodes-rv64f opcodes-rv32d opcodes-rv64d opcodes-rv32q opcodes-rv64q opcodes-rv32b opcodes-rv64b opcodes-system opcodes-rv32zfh opcodes-rv32d-zfh opcodes-rv32q-zfh opcodes-rv64zfh opcodes-rvk opcodes-rv32k opcodes-rv64k
 ALL_REAL_OPCODES := $(ALL_REAL_ILEN32_OPCODES) opcodes-rvc opcodes-rv32c opcodes-rv64c opcodes-custom opcodes-rvv
 
 ALL_OPCODES := opcodes-pseudo $(ALL_REAL_OPCODES) opcodes-rvv-pseudo

--- a/opcodes-rv32k
+++ b/opcodes-rv32k
@@ -1,0 +1,21 @@
+
+#
+# This file contains opcode specifications for the RISC-V
+# Scalar Cryptographic instruction set extension.
+# These instructions appear in _only_ RV32.
+# ------------------------------------------------------------
+
+# Scalar AES - RV32
+aes32esmi     rt     rs2 bs 11..7=0 29..25=0b11011 14..12=0 6..0=0x33
+aes32esi      rt     rs2 bs 11..7=0 29..25=0b11001 14..12=0 6..0=0x33
+aes32dsmi     rt     rs2 bs 11..7=0 29..25=0b11111 14..12=0 6..0=0x33
+aes32dsi      rt     rs2 bs 11..7=0 29..25=0b11101 14..12=0 6..0=0x33
+
+# Scalar SHA512 - RV32
+sha512sum0r   rd rs1 rs2    31..30=1 29..25=0b01000 14..12=0 6..0=0x33
+sha512sum1r   rd rs1 rs2    31..30=1 29..25=0b01001 14..12=0 6..0=0x33
+sha512sig0l   rd rs1 rs2    31..30=1 29..25=0b01010 14..12=0 6..0=0x33
+sha512sig0h   rd rs1 rs2    31..30=1 29..25=0b01110 14..12=0 6..0=0x33
+sha512sig1l   rd rs1 rs2    31..30=1 29..25=0b01011 14..12=0 6..0=0x33
+sha512sig1h   rd rs1 rs2    31..30=1 29..25=0b01111 14..12=0 6..0=0x33
+

--- a/opcodes-rv32k
+++ b/opcodes-rv32k
@@ -2,7 +2,7 @@
 #
 # This file contains opcode specifications for the RISC-V
 # Scalar Cryptographic instruction set extension.
-# These instructions appear in _only_ RV32.
+# These instructions appear _only_ in RV32.
 # ------------------------------------------------------------
 
 # Scalar AES - RV32
@@ -18,4 +18,3 @@ sha512sig0l   rd rs1 rs2    31..30=1 29..25=0b01010 14..12=0 6..0=0x33
 sha512sig0h   rd rs1 rs2    31..30=1 29..25=0b01110 14..12=0 6..0=0x33
 sha512sig1l   rd rs1 rs2    31..30=1 29..25=0b01011 14..12=0 6..0=0x33
 sha512sig1h   rd rs1 rs2    31..30=1 29..25=0b01111 14..12=0 6..0=0x33
-

--- a/opcodes-rv64k
+++ b/opcodes-rv64k
@@ -1,0 +1,22 @@
+
+#
+# This file contains opcode specifications for the RISC-V
+# Scalar Cryptographic instruction set extension.
+# These instructions appear in _only_ RV64.
+# ------------------------------------------------------------
+
+# Scalar AES - RV64
+aes64ks1i  rd rs1 rcon 31..30=0 29..25=0b11000 24=1     14..12=0b001 6..0=0x13
+aes64im    rd rs1      31..30=0 29..25=0b11000 24..20=0b0000 14..12=0b001 6..0=0x13
+aes64ks2   rd rs1 rs2  31..30=1 29..25=0b11111          14..12=0b000 6..0=0x33
+aes64esm   rd rs1 rs2  31..30=0 29..25=0b11011          14..12=0b000 6..0=0x33
+aes64es    rd rs1 rs2  31..30=0 29..25=0b11001          14..12=0b000 6..0=0x33
+aes64dsm   rd rs1 rs2  31..30=0 29..25=0b11111          14..12=0b000 6..0=0x33
+aes64ds    rd rs1 rs2  31..30=0 29..25=0b11101          14..12=0b000 6..0=0x33
+
+# Scalar SHA512 - RV64
+sha512sum0 rd rs1  31..30=0 29..25=0b01000 24..20=0b00100 14..12=1 6..0=0x13
+sha512sum1 rd rs1  31..30=0 29..25=0b01000 24..20=0b00101 14..12=1 6..0=0x13
+sha512sig0 rd rs1  31..30=0 29..25=0b01000 24..20=0b00110 14..12=1 6..0=0x13
+sha512sig1 rd rs1  31..30=0 29..25=0b01000 24..20=0b00111 14..12=1 6..0=0x13
+

--- a/opcodes-rv64k
+++ b/opcodes-rv64k
@@ -2,7 +2,7 @@
 #
 # This file contains opcode specifications for the RISC-V
 # Scalar Cryptographic instruction set extension.
-# These instructions appear in _only_ RV64.
+# These instructions appear _only_ in RV64.
 # ------------------------------------------------------------
 
 # Scalar AES - RV64
@@ -19,4 +19,3 @@ sha512sum0 rd rs1  31..30=0 29..25=0b01000 24..20=0b00100 14..12=1 6..0=0x13
 sha512sum1 rd rs1  31..30=0 29..25=0b01000 24..20=0b00101 14..12=1 6..0=0x13
 sha512sig0 rd rs1  31..30=0 29..25=0b01000 24..20=0b00110 14..12=1 6..0=0x13
 sha512sig1 rd rs1  31..30=0 29..25=0b01000 24..20=0b00111 14..12=1 6..0=0x13
-

--- a/opcodes-rvk
+++ b/opcodes-rvk
@@ -1,0 +1,24 @@
+
+#
+# This file contains opcode specifications for the RISC-V
+# Scalar Cryptographic instruction set extension.
+# These instructions appear in _both_ RV32 and RV64.
+# ------------------------------------------------------------
+
+# Poll Entropy / Get Noise Pseudo Instructions
+@pollentropy  rd 19..15=0 31..20=0xF15 14..12=0 6..0=0b1110011
+@getnoise     rd 19..15=0 31..20=0x7A9 14..12=0 6..0=0b1110011
+
+# Scalar SM4 - RV32, RV64
+sm4ed         rt rs2 bs 11..7=0 29..25=0b11000 14..12=0 6..0=0x33
+sm4ks         rt rs2 bs 11..7=0 29..25=0b11010 14..12=0 6..0=0x33
+
+# Scalar SM3 - RV32, RV64
+sm3p0         rd rs1 31..30=0 29..25=0b01000 24..20=0b01000 14..12=1 6..0=0x13
+sm3p1         rd rs1 31..30=0 29..25=0b01000 24..20=0b01001 14..12=1 6..0=0x13
+
+# Scalar SHA256 - RV32/RV64
+sha256sum0    rd rs1 31..30=0 29..25=0b01000 24..20=0b00000 14..12=1 6..0=0x13
+sha256sum1    rd rs1 31..30=0 29..25=0b01000 24..20=0b00001 14..12=1 6..0=0x13
+sha256sig0    rd rs1 31..30=0 29..25=0b01000 24..20=0b00010 14..12=1 6..0=0x13
+sha256sig1    rd rs1 31..30=0 29..25=0b01000 24..20=0b00011 14..12=1 6..0=0x13

--- a/parse_opcodes
+++ b/parse_opcodes
@@ -16,6 +16,7 @@ arguments = {}
 
 arglut = {}
 arglut['rd'] = (11,7)
+arglut['rt'] = (19,15) # source+dest register address. Overlaps rs1.
 arglut['rs1'] = (19,15)
 arglut['rs2'] = (24,20)
 arglut['rs3'] = (31,27)
@@ -35,6 +36,8 @@ arglut['bimm12lo'] = (11,7)
 arglut['zimm'] = (19,15)
 arglut['shamt'] = (25,20)
 arglut['shamtw'] = (24,20)
+arglut['bs'] = (31,30) # byte select for RV32K AES
+arglut['rcon'] = (23,20) # round constant for RV64 AES
 
 # for vectors
 arglut['vd'] = (11,7)
@@ -48,7 +51,54 @@ arglut['nf'] = (31,29)
 arglut['simm5'] = (19,15)
 arglut['zimm11'] = (30,20)
 
+#
+# These lists allow instructions which only appear in either the RV32 or
+# RV64 base architectures to overlap their opcodes.
 
+# Instructions which are _only_ in RV32
+rv32_only = [
+    "aes32esmi",
+    "aes32esi",
+    "aes32dsmi",
+    "aes32dsi",
+    "sha512sum0r",
+    "sha512sum1r",
+    "sha512sig0l",
+    "sha512sig0h",
+    "sha512sig1l",
+    "sha512sig1h"
+]
+
+# Instructions which are _only_ in RV64
+rv64_only = [
+    "aes64ks1i",
+    "aes64im",
+    "aes64ks2",
+    "aes64esm",
+    "aes64es",
+    "aes64dsm",
+    "aes64ds",
+    "sha512sum0",
+    "sha512sum1",
+    "sha512sig0",
+    "sha512sig1"
+]
+
+# Check rv32_only and rv64_only don't have shared elements.
+for a in rv32_only:
+    assert (not a in rv64_only), ("Instruction '%s' marked as both RV32 only, and RV64 only." % a)
+
+def different_base_isa(name1, name2):
+    """
+    Check if the two supplied instructions are mutually exclusive on
+    the base ISA they depend on. That is, they can never both be decoded
+    under the same XLEN.
+    """
+    return (name1 in rv32_only) and (name2 in rv64_only) or \
+           (name2 in rv32_only) and (name1 in rv64_only)
+
+#
+# Trap cause codes
 causes = [
   (0x00, 'misaligned fetch'),
   (0x01, 'fetch access'),
@@ -295,6 +345,9 @@ csrs = [
   (0xF12, 'marchid'),
   (0xF13, 'mimpid'),
   (0xF14, 'mhartid'),
+  (0xF15, 'mentropy'), # crypto ext
+
+  (0x7A9, 'mnoise'),
 ]
 
 csrs32 = [
@@ -397,7 +450,18 @@ def make_c(match,mask):
   for name in namelist:
     name2 = name.replace('.','_')
     print('DECLARE_INSN(%s, MATCH_%s, MASK_%s)' % (name2, name2.upper(), name2.upper()))
-  print('#endif')
+  print("#ifdef DECLARE_RV32_ONLY")
+  for name in namelist:
+    if name in rv32_only:
+      print("DECLARE_RV32_ONLY(%s)" % name)
+  print("#endif") #ifdef DECLARE_RV32_ONLY
+
+  print("#ifdef DECLARE_RV64_ONLY")
+  for name in namelist:
+    if name in rv64_only:
+      print("DECLARE_RV64_ONLY(%s)" % name)
+  print("#endif") # #ifdef DECLARE_RV64_ONLY
+  print('#endif') # #ifdef DECLARE_INSN
 
   print('#ifdef DECLARE_CSR')
   for num, name in csrs+csrs32:
@@ -1100,7 +1164,12 @@ def parse_inputs(args):
       else:
         for name2,match2 in match.items():
           if name2 not in pseudos and (match2 & mymask) == mymatch:
-            sys.exit("%s and %s overlap" % (name,name2))
+            if(different_base_isa(name, name2)):
+              # The instructions cannot collide, as they exist under
+              # different base ISAs.
+              continue
+            else:
+              sys.exit("%s and %s overlap" % (name,name2))
 
       mask[name] = mymask
       match[name] = mymatch

--- a/parse_opcodes
+++ b/parse_opcodes
@@ -346,7 +346,6 @@ csrs = [
   (0xF13, 'mimpid'),
   (0xF14, 'mhartid'),
   (0xF15, 'mentropy'), # crypto ext
-
   (0x7A9, 'mnoise'),
 ]
 


### PR DESCRIPTION
Hi there

This PR does what it says on the tin, it also adds some support to the `parse_opcodes` script for allowing instructions to be decoded in the context of `XLEN`, particularly for the Spike `encoding.h` file. It relates to riscv/riscv-isa-sim#649. See the commit message for a little more information.

Note that these opcodes are *currently* going through the opcode and consistency review process, shortly behind Bitmanip.

While the Spike issue is open, this PR may need to be iterated on, since the best mechanism for enabling Spike (and other consumers of this information) to decode instructions in the context of `XLEN` is still ongoing. Scalar Crypto is the first extension to run into this issue, but likely won't be the last.

I opted for the simplest approach for tagging instructions as RV32/RV64 only - a manual list inside `parse_opcodes`. This could be dynamically populated in the future, but I wanted something simple and bullet proof for the first implementation.

As ever, happy to iterate if a better solution exists.

Thanks,
Ben