### PR TITLE
Move shift instructions to opcodes-rv64i

### DIFF
--- a/opcodes-rv32i
+++ b/opcodes-rv32i
@@ -22,12 +22,9 @@ lui     rd imm20 6..2=0x0D 1..0=3
 auipc   rd imm20 6..2=0x05 1..0=3
 
 addi    rd rs1 imm12           14..12=0 6..2=0x04 1..0=3
-slli    rd rs1 31..26=0  shamt 14..12=1 6..2=0x04 1..0=3
 slti    rd rs1 imm12           14..12=2 6..2=0x04 1..0=3
 sltiu   rd rs1 imm12           14..12=3 6..2=0x04 1..0=3
 xori    rd rs1 imm12           14..12=4 6..2=0x04 1..0=3
-srli    rd rs1 31..26=0  shamt 14..12=5 6..2=0x04 1..0=3
-srai    rd rs1 31..26=16 shamt 14..12=5 6..2=0x04 1..0=3
 ori     rd rs1 imm12           14..12=6 6..2=0x04 1..0=3
 andi    rd rs1 imm12           14..12=7 6..2=0x04 1..0=3
 

--- a/opcodes-rv64i
+++ b/opcodes-rv64i
@@ -15,3 +15,8 @@ ld      rd rs1       imm12 14..12=3 6..2=0x00 1..0=3
 lwu     rd rs1       imm12 14..12=6 6..2=0x00 1..0=3
 
 sd     imm12hi rs1 rs2 imm12lo 14..12=3 6..2=0x08 1..0=3
+
+# RV32 versions of these are in opcodes-pseudo
+slli    rd rs1 31..26=0  shamt 14..12=1 6..2=0x04 1..0=3
+srli    rd rs1 31..26=0  shamt 14..12=5 6..2=0x04 1..0=3
+srai    rd rs1 31..26=16 shamt 14..12=5 6..2=0x04 1..0=3


### PR DESCRIPTION
The shamt field is 6 bits wide, so doesn't belong in opcodes-rv32i.

The opcodes-pseudo file still contains the RV32 versions with shamtw.