### PR TITLE
Modernize to Python 3

### DIFF
--- a/parse_opcodes
+++ b/parse_opcodes
@@ -1,8 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
-from builtins import hex
-from builtins import range
 import math
 import sys
 import tokenize


### PR DESCRIPTION
Python2 has already been deprecated in 2020
This also removes the dependency of python2-future

Ref to #22