### PR TITLE
Fix incorrect encoding output in instr_dict.yaml.

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -109,7 +109,7 @@ def process_enc_line(line, ext):
     # check if all args of the instruction are present in arg_lut present in
     # constants.py
     args = single_fixed.sub(' ', remaining).split()
-    encoding_args = encoding
+    encoding_args = encoding.copy()
     for a in args:
         if a not in arg_lut:
             logging.error(f' Found variable {a} in instruction {name} whose mapping in arg_lut does not exist')


### PR DESCRIPTION
#122 introduced this change in `instr_dict.yaml`, which unless I am mistaken is incorrect:
```yaml
add:
  encoding: 0000000rs2rs2rs2rs2rs2rs1rs1rs1rs1rs1000rdrdrdrdrd0110011
  extension:
  - rv_i
  mask: '0xfe00707f'
  match: '0x33'
  variable_fields:
  - rd
  - rs1
  - rs2
add16:
  encoding: 0100000rs2rs2rs2rs2rs2rs1rs1rs1rs1rs1000rdrdrdrdrd1110111
  extension:
```