### PR TITLE
Generalize `fence.tso` instruction

### DIFF
--- a/rv_i
+++ b/rv_i
@@ -36,7 +36,7 @@ or      rd rs1 rs2 31..25=0  14..12=6 6..2=0x0C 1..0=3
 and     rd rs1 rs2 31..25=0  14..12=7 6..2=0x0C 1..0=3
 fence fm pred succ rs1 14..12=0 rd 6..2=0x03 1..0=3
 #specialized fences
-$pseudo_op rv_i::fence fence.tso 31..28=8 27..24=3 23..20=3 19..15=0 14..12=0 11..7=0 6..2=0x03 1..0=3
+$pseudo_op rv_i::fence fence.tso 31..28=8 27..24=3 23..20=3 rs1 14..12=0 rd 6..2=0x03 1..0=3
 $pseudo_op rv_i::fence pause     31..28=0 27..24=1 23..20=0 19..15=0      14..12=0 11..7=0      6..2=0x03 1..0=3
 ecall    31..20=0x000 19..7=0 6..2=0x1C 1..0=3
 ebreak   31..20=0x001 19..7=0 6..2=0x1C 1..0=3


### PR DESCRIPTION
`fence.tso` instruction is encoded as a `FENCE` instruction with `fm=1000`, predecessor=`RW`, and successor=`RW` (as per the ISA Manual).

This commit generalizes `fence.tso` instruction to have unused *rs1* and *rd* operands (shall be zero on standard software).

In this PR, `fence.tso` is encoded like `fence` and `fence.i` instructions (that have generalized forms on riscv-opcodes).

## Not a Request: `pause` from `Zihintntl`

Note that `pause` instruction must not be edited like this because (quoting the ISA Manual),

> `PAUSE` is encoded as a `FENCE` instruction with *pred*=`W`, *succ*=`0`, *fm*=`0`, *rd*=`x0`, and *rs1*=`x0`.