### PR TITLE
throw error when args contains a variety of base extensions

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -133,6 +133,9 @@ def process_enc_line(line, ext):
 
     return (name, single_dict)
 
+def get_base_ext (ext_name):
+  return ext_name.split("_")[0]
+
 def same_base_ext (ext_name, ext_name_list):
     type1 = ext_name.split("_")[0]
     for ext_name1 in ext_name_list:
@@ -933,6 +936,17 @@ def signed(value, width):
   else:
     return value - (1<<width)
 
+def check_extensions (extensions):
+  base_ext = "rv"
+  for ext_name in extensions:
+    ext = get_base_ext(ext_name)
+    if base_ext == ext or ext == "rv":
+      continue
+    elif base_ext == "rv":
+      base_ext = ext
+    else:
+      logging.error("Contains a variety of base extensions")
+      sys.exit(1)
 
 if __name__ == "__main__":
     print(f'Running with args : {sys.argv}')
@@ -942,6 +956,8 @@ if __name__ == "__main__":
         if i in extensions:
             extensions.remove(i)
     print(f'Extensions selected : {extensions}')
+
+    check_extensions(extensions)
 
     include_pseudo = False
     if "-go" in sys.argv[1:]:

--- a/parse.py
+++ b/parse.py
@@ -137,9 +137,9 @@ def get_base_ext (ext_name):
   return ext_name.split("_")[0]
 
 def same_base_ext (ext_name, ext_name_list):
-    type1 = ext_name.split("_")[0]
+    type1 = get_base_ext(ext_name)
     for ext_name1 in ext_name_list:
-        type2 = ext_name1.split("_")[0]
+        type2 = get_base_ext(ext_name1)
         # "rv" mean insn for rv32 and rv64
         if (type1 == type2 or
             (type2 == "rv" and (type1 == "rv32" or type1 == "rv64")) or


### PR DESCRIPTION
When use parser.py to generate encoding.out.h, the RV32I and RV64I SLLI instruction has the same marco name MATCH_SLLI and MASK_SLLI but diffrentent code encoding. So I think there need some check for this situation.