### PR TITLE
Fix pack instruction in unratified/rv_zbpbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Instruction syntaxes used in this project are broadly categorized into three:
   instruction, as this avoids existence of overlapping opcodes for users who are
   experimenting with unratified extensions as well.
   
-- **imported_instructions** - these are instructions which are borrowed from an extension into a new/different extension/sub-extension. Only regular instructions can be imported. Pseudo-op instructions cannot be imported. Example:
+- **imported_instructions** - these are instructions which are borrowed from an extension into a new/different extension/sub-extension. Only regular instructions can be imported. Pseudo-op or already imported instructions cannot be imported. Example:
   ```
   $import rv32_zkne::aes32esmi
   ```

--- a/parse.py
+++ b/parse.py
@@ -357,14 +357,14 @@ def create_inst_dict(file_filter, include_pseudo=False, include_pseudo_ops=[]):
             # extension. Else throw error.
             found = False
             for oline in open(ext_file):
-                if not re.findall(f'^\s*{reg_instr}',oline):
+                if not re.findall(f'^\s*{reg_instr}\s+',oline):
                     continue
                 else:
                     found = True
                     break
             if not found:
                 logging.error(f'imported instruction {reg_instr} not found in {ext_file}. Required by {line} present in {f}')
-                logging.error(f'Note: you cannot import pseudo ops.')
+                logging.error(f'Note: you cannot import pseudo/imported ops.')
                 raise SystemExit(1)
 
             # call process_enc_line to get the data about the current

--- a/unratified/rv_zbpbo
+++ b/unratified/rv_zbpbo
@@ -1,4 +1,4 @@
-$import rv_zbp::pack
+$import rv_zbe::pack
 $import rv_zbp::packu
 $import rv_zbb::max
 $import rv_zbb::min


### PR DESCRIPTION
pack instruction should be imported from zbe -- instead of zbp. 

**Pack** instruction is currently defined in **unratified/zbe** 

Signed-off-by: Babu P S <11073327+eflaner@users.noreply.github.com>