### PR TITLE
Fix issues from #153

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ Instruction syntaxes used in this project are broadly categorized into three:
   ```
   $import rv32_zkne::aes32esmi
   ```
+
+### RESTRICTIONS
+
+Following are the restrictions one should keep in mind while defining $pseudo\_ops and $imported\_ops
+
+- Pseudo-op or already imported instructions cannot be imported again in another file. One should
+  always import base-instructions only.
+- While defining a $pseudo\_op, the base-instruction itself cannot be a $pseudo\_op
+
 ## Flow for parse.py
 
 The `parse.py` python file is used to perform checks on the current set of instruction encodings and also generates multiple artifacts : latex tables, encoding.h header file, etc. This section will provide a brief overview of the flow within the python file.

--- a/parse.py
+++ b/parse.py
@@ -290,7 +290,7 @@ def create_inst_dict(file_filter, include_pseudo=False, include_pseudo_ops=[]):
             # extension. Else throw error.
             found = False
             for oline in open(ext_file):
-                if not re.findall(f'^\s*{orig_inst}',oline):
+                if not re.findall(f'^\s*{orig_inst}\s+',oline):
                     continue
                 else:
                     found = True

--- a/parse.py
+++ b/parse.py
@@ -310,9 +310,9 @@ def create_inst_dict(file_filter, include_pseudo=False, include_pseudo_ops=[]):
                 # update the final dict with the instruction
                 if name not in instr_dict:
                     instr_dict[name] = single_dict
-                    logging.debug(f'    including pseudo_ops:{name}')
+                    logging.debug(f'        including pseudo_ops:{name}')
             else:
-                logging.debug(f'Skipping pseudo_op {pseudo_inst} since original instruction {orig_inst} already selected in list')
+                logging.debug(f'        Skipping pseudo_op {pseudo_inst} since original instruction {orig_inst} already selected in list')
 
     # third pass if for imported instructions
     logging.debug('Collecting imported instructions')

--- a/rv32_i
+++ b/rv32_i
@@ -1,3 +1,6 @@
 $pseudo_op rv64_i::slli slli rd rs1 shamtw 31..25=0  14..12=1 6..2=0x04 1..0=3
 $pseudo_op rv64_i::srli srli rd rs1 shamtw 31..25=0  14..12=5 6..2=0x04 1..0=3
 $pseudo_op rv64_i::srai srai rd rs1 shamtw 31..25=32 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_i::slli slli_rv32 rd rs1 shamtw 31..25=0  14..12=1 6..2=0x04 1..0=3
+$pseudo_op rv64_i::srli srli_rv32 rd rs1 shamtw 31..25=0  14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_i::srai srai_rv32 rd rs1 shamtw 31..25=32 14..12=5 6..2=0x04 1..0=3

--- a/rv32_i
+++ b/rv32_i
@@ -1,3 +1,3 @@
-$pseudo_op rv128_i::slli slli_rv32 rd rs1 shamtw 31..25=0  14..12=1 6..2=0x04 1..0=3
-$pseudo_op rv128_i::srli srli_rv32 rd rs1 shamtw 31..25=0  14..12=5 6..2=0x04 1..0=3
-$pseudo_op rv128_i::srai srai_rv32 rd rs1 shamtw 31..25=32 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_i::slli slli rd rs1 shamtw 31..25=0  14..12=1 6..2=0x04 1..0=3
+$pseudo_op rv64_i::srli srli rd rs1 shamtw 31..25=0  14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_i::srai srai rd rs1 shamtw 31..25=32 14..12=5 6..2=0x04 1..0=3

--- a/unratified/rv128_i
+++ b/unratified/rv128_i
@@ -16,6 +16,9 @@ ldu     rd rs1       imm12 14..12=7 6..2=0x00 1..0=3
 
 sq     imm12hi rs1 rs2 imm12lo 14..12=4 6..2=0x08 1..0=3
 
+$pseudo_op rv64_i::slli slli    rd rs1 31..27=0  shamtq 14..12=1 6..2=0x04 1..0=3
+$pseudo_op rv64_i::srli srli    rd rs1 31..27=0  shamtq 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_i::srai srai    rd rs1 31..27=8  shamtq 14..12=5 6..2=0x04 1..0=3
 $pseudo_op rv64_i::slli slli_rv128 rd rs1 31..27=0  shamtq 14..12=1 6..2=0x04 1..0=3
 $pseudo_op rv64_i::srli srli_rv128 rd rs1 31..27=0  shamtq 14..12=5 6..2=0x04 1..0=3
 $pseudo_op rv64_i::srai srai_rv128 rd rs1 31..27=8  shamtq 14..12=5 6..2=0x04 1..0=3


### PR DESCRIPTION
In #153 a couple of issues were introduced:
- the mnemonics of the shift-immediate ops in rv32 and rv128 (slli, srai and srli) were **replaced** with `_rv<xlen>` suffix - causing incompatibility to prior versions.
- the shift immediate ops in rv32_i were introduced as pseudo_ops of equivalents in rv128_i - which is wrong since in rv128_i the shift-immediates themselses are pseudo_ops of rv64_i
- the above caused a change in the Latex table for rv32i instruction names for shift ops by adding a suffix `.RV32`

This PR fixes the above issues by: 
- updating the checks in parse.py to ensure that pseudo ops are not dependent on other pseudo ops
- the intent of `PR#153` has been captured by **adding** the required pseudo ops instead of replacing the current ones.
- Updated the README on restrictions on usage of pseudo and imported ops

I have confirmed that the outputs for encoding.out.h remain the same as those from #153 