### PR TITLE
Fix merging of instructions with the same name

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -247,8 +247,10 @@ def create_inst_dict(file_filter, include_pseudo=False, include_pseudo_ops=[]):
                       err_msg += f'added from {item["extension"]} in same base extensions'
                       logging.error(err_msg)
                       raise SystemExit(1)
-            # update the final dict with the instruction
-            instr_dict[name] = single_dict
+
+            if name not in instr_dict:
+                # update the final dict with the instruction
+                instr_dict[name] = single_dict
 
     # second pass if for pseudo instructions
     logging.debug('Collecting pseudo instructions now')
@@ -382,10 +384,10 @@ def create_inst_dict(file_filter, include_pseudo=False, include_pseudo_ops=[]):
                     err_msg += f'added from {var} but each have different encodings for the same instruction'
                     logging.error(err_msg)
                     raise SystemExit(1)
-                instr_dict[name]['extension'].append(single_dict['extension'])
-
-            # update the final dict with the instruction
-            instr_dict[name] = single_dict
+                instr_dict[name]['extension'].extend(single_dict['extension'])
+            else:
+                # update the final dict with the instruction
+                instr_dict[name] = single_dict
     return instr_dict
 
 def make_priv_latex_table():


### PR DESCRIPTION
This fixes generation of 'extension' field for `instr_dict.yaml`. If an instruction exists in multiple extensions, only one of them shows up:

```yaml
andn:
  encoding: 0100000----------111-----0110011
  extension:
  - rv_zbkb
  mask: '0xfe00707f'
  match: '0x40007033'
  variable_fields:
  - rd
  - rs1
  - rs2
```

Now it's fixed to show all extensions:

```yaml
andn:
  encoding: 0100000----------111-----0110011
  extension:
  - rv_zbb
  - rv_zbkb
  mask: '0xfe00707f'
  match: '0x40007033'
  variable_fields:
  - rd
  - rs1
  - rs2
```

I'm not familiar with `parse.py` so I'm not sure if this is correct, but it did (at least seem to) fix the problem I was having.
