### PR TITLE
Update encodings for vfwmaccbf16.vv/vf

### DIFF
--- a/unratified/rv_zvfbfwma
+++ b/unratified/rv_zvfbfwma
@@ -1,2 +1,2 @@
-vfwmaccbf16.vv     31..26=0x23 vm vs2 vs1 14..12=0x1 vd 6..0=0x57
-vfwmaccbf16.vf     31..26=0x23 vm vs2 rs1 14..12=0x5 vd 6..0=0x57
+vfwmaccbf16.vv     31..26=0x3B vm vs2 vs1 14..12=0x1 vd 6..0=0x57
+vfwmaccbf16.vf     31..26=0x3B vm vs2 rs1 14..12=0x5 vd 6..0=0x57


### PR DESCRIPTION
Because the missed quotes in the adoc file,  the encodings for vfwmaccbf16.vv/vf are wrong in its generate pdf spec: https://github.com/riscv/riscv-bfloat16