### PR TITLE
Add argparse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 EXTENSIONS := "rv*" "unratified/rv*"
+SPIKE_EXTENSIONS := "rv*" "unratified/rv_*" "unratified/rv32*" "unratified/rv64*"
+SPIKE_PSEUDO_OPS := 'pause' 'prefetch_i' 'prefetch_r' 'prefetch_w' 'rstsa16' 'rstsa32' 'srli32_u' 'slli_rv128' 'slli_rv32' 'srai_rv128' 'srai_rv32' 'srli_rv128' 'srli_rv32' 'umax32'
 ISASIM_H := ../riscv-isa-sim/riscv/encoding.h
 PK_H := ../riscv-pk/machine/encoding.h
 ENV_H := ../riscv-tests/env/encoding.h
@@ -9,38 +11,38 @@ default: everything
 
 .PHONY : everything
 everything:
-	@./parse.py -c -go -chisel -sverilog -rust -latex -spinalhdl $(EXTENSIONS)
+	@./parse.py -c -go -chisel -sverilog -rust -latex -spinalhdl -include_pseudo -extensions $(EXTENSIONS)
 
 .PHONY : encoding.out.h
 encoding.out.h:
-	@./parse.py -c rv* unratified/rv_* unratified/rv32* unratified/rv64*
+	@./parse.py -c -include_pseudo -pseudo_ops $(SPIKE_PSEUDO_OPS) -extensions $(SPIKE_EXTENSIONS)
 
 .PHONY : inst.chisel
 inst.chisel:
-	@./parse.py -chisel $(EXTENSIONS)
+	@./parse.py -chisel -extensions $(EXTENSIONS)
 
 .PHONY : inst.go
 inst.go:
-	@./parse.py -go $(EXTENSIONS)
+	@./parse.py -go -include_pseudo -extensions $(EXTENSIONS)
 
 .PHONY : latex
 latex:
-	@./parse.py -latex $(EXTENSIONS)
+	@./parse.py -latex -extensions $(EXTENSIONS)
 
 .PHONY : inst.sverilog
 inst.sverilog:
-	@./parse.py -sverilog $(EXTENSIONS)
+	@./parse.py -sverilog -extensions $(EXTENSIONS)
 
 .PHONY : inst.rs
 inst.rs:
-	@./parse.py -rust $(EXTENSIONS)
+	@./parse.py -rust -extensions $(EXTENSIONS)
 
 .PHONY : clean
 clean:
 	rm -f inst* priv-instr-table.tex encoding.out.h
 
 .PHONY : install
-install: everything
+install: encoding.out.h
 	set -e; for FILE in $(INSTALL_HEADER_FILES); do cp -f encoding.out.h $$FILE; done
 
 .PHONY: instr-table.tex


### PR DESCRIPTION
Argparse will be helpful to make more complex changes to the parsing of command line arguments. This causes breaking changes to the parse.py API but the Makefile is appropriately updated.

I am not sure if this was intended, but logically it seems the "include_pseudo" flag should only include pseudo ops if it is True. The previous behavior was to include pseudo_ops even when the flag was False but the pseudo_op was not already included. Changing the flag to True would then force a pseudo_op to be included even if it was already included.