### PR TITLE
retain the original shift instructions as pseudo-ops as well

### DIFF
--- a/rv32_c
+++ b/rv32_c
@@ -1,5 +1,8 @@
 # quadrant 1
 c.jal c_imm12              1..0=1 15..13=1
+$pseudo_op rv64_c::c.srli c.srli rd_rs1_p c_nzuimm5  1..0=1 15..13=4 12..10=0
+$pseudo_op rv64_c::c.srai c.srai rd_rs1_p c_nzuimm5  1..0=1 15..13=4 12..10=1
+$pseudo_op rv64_c::c.slli c.slli rd_rs1_n0 c_nzuimm6lo  1..0=2 15..12=0 
 $pseudo_op rv64_c::c.srli c.srli_rv32 rd_rs1_p c_nzuimm5  1..0=1 15..13=4 12..10=0
 $pseudo_op rv64_c::c.srai c.srai_rv32 rd_rs1_p c_nzuimm5  1..0=1 15..13=4 12..10=1
 $pseudo_op rv64_c::c.slli c.slli_rv32 rd_rs1_n0 c_nzuimm6lo  1..0=2 15..12=0 


### PR DESCRIPTION
This is how its done in rv32_i as well. #189 replaced the original pseudo ops instead of just appending new ones. This PR fixes that.
