### PR TITLE
Add `.rv32` on rv32_zbs and rv32_zbb instructions

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -224,4 +224,7 @@ emitted_pseudo_ops = [
     'bexti.rv32',
     'binvi.rv32',
     'bseti.rv32',
+    'zext.h.rv32',
+    'rev8.h.rv32',
+    'rori.rv32',
 ]

--- a/constants.py
+++ b/constants.py
@@ -220,4 +220,8 @@ emitted_pseudo_ops = [
     'mop_rr_7',
     'sspush_x1',
     'sspush_x5',
+    'bclri.rv32',
+    'bexti.rv32',
+    'binvi.rv32',
+    'bseti.rv32',
 ]

--- a/rv32_zbb
+++ b/rv32_zbb
@@ -1,3 +1,3 @@
-$pseudo_op rv_zbe::pack     zext.h rd rs1 31..25=0x04 24..20=0 14..12=0x4 6..0=0x33 
-$pseudo_op rv64_zbp::grevi  rev8 rd rs1   31..20=0x698 14..12=5 6..0=0x13
-$pseudo_op rv64_zbb::rori   rori rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv_zbe::pack     zext.h.rv32 rd rs1 31..25=0x04 24..20=0 14..12=0x4 6..0=0x33
+$pseudo_op rv64_zbp::grevi  rev8.rv32 rd rs1   31..20=0x698 14..12=5 6..0=0x13
+$pseudo_op rv64_zbb::rori   rori.rv32 rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3

--- a/rv32_zbkb
+++ b/rv32_zbkb
@@ -1,4 +1,4 @@
 $pseudo_op rv64_zbp::shfli    zip rd rs1 31..25=4 24..20=15 14..12=1 6..2=4 1..0=3 
 $pseudo_op rv64_zbp::unshfli  unzip rd rs1 31..25=4 24..20=15 14..12=5 6..2=4 1..0=3 
-$pseudo_op rv64_zbb::rori     rori rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3
-$pseudo_op rv64_zbp::grevi    rev8 rd rs1   31..20=0x698 14..12=5 6..0=0x13
+$pseudo_op rv64_zbb::rori     rori.rv32 rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_zbp::grevi    rev8.rv32 rd rs1   31..20=0x698 14..12=5 6..0=0x13

--- a/rv32_zbs
+++ b/rv32_zbs
@@ -1,5 +1,5 @@
-$pseudo_op rv64_zbs::bclri bclri rd rs1 31..25=0x24 shamtw 14..12=1 6..2=0x04 1..0=3
-$pseudo_op rv64_zbs::bexti bexti rd rs1 31..25=0x24 shamtw 14..12=5 6..2=0x04 1..0=3
-$pseudo_op rv64_zbs::binvi binvi rd rs1 31..25=0x34 shamtw 14..12=1 6..2=0x04 1..0=3
-$pseudo_op rv64_zbs::bseti bseti rd rs1 31..25=0x14 shamtw 14..12=1 6..2=0x04 1..0=3
+$pseudo_op rv64_zbs::bclri bclri.rv32 rd rs1 31..25=0x24 shamtw 14..12=1 6..2=0x04 1..0=3
+$pseudo_op rv64_zbs::bexti bexti.rv32 rd rs1 31..25=0x24 shamtw 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_zbs::binvi binvi.rv32 rd rs1 31..25=0x34 shamtw 14..12=1 6..2=0x04 1..0=3
+$pseudo_op rv64_zbs::bseti bseti.rv32 rd rs1 31..25=0x14 shamtw 14..12=1 6..2=0x04 1..0=3
 

--- a/rv32_zk
+++ b/rv32_zk
@@ -1,8 +1,8 @@
 #import zbkb
 $pseudo_op rv64_zbp::shfli    zip rd rs1 31..25=4 24..20=15 14..12=1 6..2=4 1..0=3 
 $pseudo_op rv64_zbp::unshfli  unzip rd rs1 31..25=4 24..20=15 14..12=5 6..2=4 1..0=3 
-$pseudo_op rv64_zbb::rori     rori rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3
-$pseudo_op rv64_zbp::grevi    rev8 rd rs1   31..20=0x698 14..12=5 6..0=0x13
+$pseudo_op rv64_zbb::rori     rori.rv32 rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_zbp::grevi    rev8.rv32 rd rs1   31..20=0x698 14..12=5 6..0=0x13
 
 #import zkne
 $import rv32_zkne::aes32esmi

--- a/rv32_zkn
+++ b/rv32_zkn
@@ -1,8 +1,8 @@
 #import zbkb
 $pseudo_op rv64_zbp::shfli    zip rd rs1 31..25=4 24..20=15 14..12=1 6..2=4 1..0=3 
 $pseudo_op rv64_zbp::unshfli  unzip rd rs1 31..25=4 24..20=15 14..12=5 6..2=4 1..0=3 
-$pseudo_op rv64_zbb::rori     rori rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3
-$pseudo_op rv64_zbp::grevi    rev8 rd rs1   31..20=0x698 14..12=5 6..0=0x13
+$pseudo_op rv64_zbb::rori     rori.rv32 rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_zbp::grevi    rev8.rv32 rd rs1   31..20=0x698 14..12=5 6..0=0x13
 
 #import zkne
 $import rv32_zkne::aes32esmi

--- a/rv32_zks
+++ b/rv32_zks
@@ -1,6 +1,6 @@
 #import zbkb
 $pseudo_op rv64_zbp::shfli    zip rd rs1 31..25=4 24..20=15 14..12=1 6..2=4 1..0=3 
 $pseudo_op rv64_zbp::unshfli  unzip rd rs1 31..25=4 24..20=15 14..12=5 6..2=4 1..0=3 
-$pseudo_op rv64_zbb::rori     rori rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3
-$pseudo_op rv64_zbp::grevi    rev8 rd rs1   31..20=0x698 14..12=5 6..0=0x13
+$pseudo_op rv64_zbb::rori     rori.rv32 rd rs1   31..25=0x30 shamtw 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv64_zbp::grevi    rev8.rv32 rd rs1   31..20=0x698 14..12=5 6..0=0x13
 


### PR DESCRIPTION
`shamt[5]` must be 0 for RV32.
`slli.rv32`, etc.,  are defined for `slli`, `srli`, and `srai` to address this issue.
`bclri`, `bexti`, `binvi`, `bseti`, and `rori` have same issue.  This PR adds `.rv32` for them.

Similarly `zext.h` and `rev8` have different encoding for RV32 and RV64.  Only RV64 versions are emitted in output files. This PR also adds `.rv32` for them to solve this.

***

Note: `rev8` and `rori` are aliased in `rv32_{zk,zkn,zks}`. But only `rv32_zks` is shown in the `extension` field in `instr_dict.yaml`.  I think this is an issue of `parse.py`.