### PR TITLE
Add multiple $pseudo_op extensions

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -313,6 +313,8 @@ def create_inst_dict(file_filter, include_pseudo=False, include_pseudo_ops=[]):
                 if name not in instr_dict:
                     instr_dict[name] = single_dict
                     logging.debug(f'        including pseudo_ops:{name}')
+                elif instr_dict[name]['encoding'] == single_dict['encoding']:
+                    instr_dict[name]['extension'].extend(single_dict['extension'])
             else:
                 logging.debug(f'        Skipping pseudo_op {pseudo_inst} since original instruction {orig_inst} already selected in list')
 


### PR DESCRIPTION
I wrote in https://github.com/riscv/riscv-opcodes/pull/220#issue-2069941241:

> Note: rev8 and rori are aliased in rv32_{zk,zkn,zks}. But only rv32_zks is shown in the extension field in instr_dict.yaml. I think this is an issue of parse.py.

This is the fix for this issue.

For example `brev8` emits;

```diff
  brev8:
    encoding: 000010001111-----101-----0010011
    extension:
    - rv32_zks
+   - rv32_zkn
+   - rv32_zk
+   - rv32_zbkb
    mask: '0xfff0707f'
    ...
```