### PR TITLE
Add Zicfilp codes

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -220,6 +220,7 @@ emitted_pseudo_ops = [
     'mop_rr_7',
     'sspush_x1',
     'sspush_x5',
+    'lpad',
     'bclri.rv32',
     'bexti.rv32',
     'binvi.rv32',

--- a/encoding.h
+++ b/encoding.h
@@ -337,6 +337,9 @@
 #define SRMCFG_RCID  0x00000FFF
 #define SRMCFG_MCID  0x0FFF0000
 
+/* software check exception xtval codes */
+#define LANDING_PAD_FAULT 2
+
 #ifdef __riscv
 
 #if __riscv_xlen == 64

--- a/unratified/rv_zicfilp
+++ b/unratified/rv_zicfilp
@@ -1,0 +1,2 @@
+# auipc x0 imm20 -> lpad imm20
+$pseudo_op rv_i::auipc lpad imm20 11..7=0 6..2=0x05 1..0=3


### PR DESCRIPTION
This PR adds codes defined in the [Zicfilp spec](https://github.com/riscv/riscv-cfi/blob/main/cfi_forward.adoc) (commit 079216b).
It is part of the effort to support Zicfilp in spike/pk.