### PR TITLE
Add CSR fields of mtopi

### DIFF
--- a/encoding.h
+++ b/encoding.h
@@ -257,6 +257,9 @@
 #define HVICTL_IPRIOM 0x00000100
 #define HVICTL_IPRIO  0x000000FF
 
+#define MTOPI_IID   0x0FFF0000
+#define MTOPI_IPRIO 0x000000FF
+
 #define PRV_U 0
 #define PRV_S 1
 #define PRV_M 3


### PR DESCRIPTION
Add CSR fields of mtopi from the AIA extension. The mtopi, stopi, and vstopi have the same CSR fields.
![image](https://github.com/riscv/riscv-opcodes/assets/39526191/40ccfc96-b539-4939-b091-eb2918bffca9)
