### PR TITLE
Add CSR fields of mtopei

### DIFF
--- a/encoding.h
+++ b/encoding.h
@@ -260,6 +260,9 @@
 #define MTOPI_IID   0x0FFF0000
 #define MTOPI_IPRIO 0x000000FF
 
+#define MTOPEI_IID   0x7ff0000
+#define MTOPEI_IPRIO 0x00007ff
+
 #define PRV_U 0
 #define PRV_S 1
 #define PRV_M 3


### PR DESCRIPTION
Add CSR fields of mtopei from the AIA extension. The mtopei, stopei, and vstopei have the same CSR fields.
![image](https://github.com/riscv/riscv-opcodes/assets/39526191/e058fbb3-1390-49a4-b057-d9424b1357d7)
