### PR TITLE
[RFC] Add instruction assembly format information

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Instruction syntaxes used in this project are broadly categorized into three:
 - **regular instructions** :- these are instructions which hold a unique opcode in the encoding space. A very generic syntax guideline 
   for these instructions is as follows:
   ```
-  <instruction name> <arguments>
+  <instruction name> <arguments> ::: <asm format>
   ```
   where `<argument>` is either `<bit encoding>` or `<variable argument>`.
 
   Examples:
   ```
-  lui     rd imm20 6..2=0x0D 1..0=3
-  beq     bimm12hi rs1 rs2 bimm12lo 14..12=0 6..2=0x18 1..0=3
+  lui     rd imm20 6..2=0x0D 1..0=3 ::: OPC rd, imm20
+  beq     bimm12hi rs1 rs2 bimm12lo 14..12=0 6..2=0x18 1..0=3 ::: OPC rs1, rs2, bimm12
   ```
   The bit encodings are usually of 2 types: 
     - *single bit assignment* : here the value of a single bit is assigned using syntax `<bit-position>=<value>`. For e.g. `6=1` means bit 6 should be 1. Here the value must be 1 or 0.
@@ -111,6 +111,7 @@ Once the above checks are passed for a regular instruction, we then create a dic
   - mask : a 32-bit hex value indicating the bits of the encodings that must be checked for legality of that instruction
   - match : a 32-bit hex value indicating the values the encoding must take for the bits which are set as 1 in the mask above
   - variable_fields : This is list of args required by the instruction
+  - asm_format: The format of fields for valid assembly for this instruction
 
 The above dictionary elements are added to a main `instr_dict` dictionary under the instruction node. This process continues until all regular 
 instructions have been processed. In the second pass, we now process the `$pseudo_op` instructions. Here, we first check if the *base-instruction* of 

--- a/rv_a
+++ b/rv_a
@@ -1,11 +1,11 @@
-lr.w        rd rs1 24..20=0 aq rl 31..29=0 28..27=2 14..12=2 6..2=0x0B 1..0=3
-sc.w        rd rs1 rs2      aq rl 31..29=0 28..27=3 14..12=2 6..2=0x0B 1..0=3
-amoswap.w   rd rs1 rs2      aq rl 31..29=0 28..27=1 14..12=2 6..2=0x0B 1..0=3
-amoadd.w    rd rs1 rs2      aq rl 31..29=0 28..27=0 14..12=2 6..2=0x0B 1..0=3
-amoxor.w    rd rs1 rs2      aq rl 31..29=1 28..27=0 14..12=2 6..2=0x0B 1..0=3
-amoand.w    rd rs1 rs2      aq rl 31..29=3 28..27=0 14..12=2 6..2=0x0B 1..0=3
-amoor.w     rd rs1 rs2      aq rl 31..29=2 28..27=0 14..12=2 6..2=0x0B 1..0=3
-amomin.w    rd rs1 rs2      aq rl 31..29=4 28..27=0 14..12=2 6..2=0x0B 1..0=3
-amomax.w    rd rs1 rs2      aq rl 31..29=5 28..27=0 14..12=2 6..2=0x0B 1..0=3
-amominu.w   rd rs1 rs2      aq rl 31..29=6 28..27=0 14..12=2 6..2=0x0B 1..0=3
-amomaxu.w   rd rs1 rs2      aq rl 31..29=7 28..27=0 14..12=2 6..2=0x0B 1..0=3
+lr.w        rd rs1 24..20=0 aq rl 31..29=0 28..27=2 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, (rs1)
+sc.w        rd rs1 rs2      aq rl 31..29=0 28..27=3 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, (rs1)
+amoswap.w   rd rs1 rs2      aq rl 31..29=0 28..27=1 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, rs2, (rs1)
+amoadd.w    rd rs1 rs2      aq rl 31..29=0 28..27=0 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, rs2, (rs1)
+amoxor.w    rd rs1 rs2      aq rl 31..29=1 28..27=0 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, rs2, (rs1)
+amoand.w    rd rs1 rs2      aq rl 31..29=3 28..27=0 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, rs2, (rs1)
+amoor.w     rd rs1 rs2      aq rl 31..29=2 28..27=0 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, rs2, (rs1)
+amomin.w    rd rs1 rs2      aq rl 31..29=4 28..27=0 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, rs2, (rs1)
+amomax.w    rd rs1 rs2      aq rl 31..29=5 28..27=0 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, rs2, (rs1)
+amominu.w   rd rs1 rs2      aq rl 31..29=6 28..27=0 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, rs2, (rs1)
+amomaxu.w   rd rs1 rs2      aq rl 31..29=7 28..27=0 14..12=2 6..2=0x0B 1..0=3 ::: OPC rd, rs2, (rs1)

--- a/rv_i
+++ b/rv_i
@@ -1,47 +1,47 @@
 # rv_i
 
-lui     rd imm20 6..2=0x0D 1..0=3
-auipc   rd imm20 6..2=0x05 1..0=3
-jal     rd jimm20                          6..2=0x1b 1..0=3
-jalr    rd rs1 imm12              14..12=0 6..2=0x19 1..0=3
-beq     bimm12hi rs1 rs2 bimm12lo 14..12=0 6..2=0x18 1..0=3
-bne     bimm12hi rs1 rs2 bimm12lo 14..12=1 6..2=0x18 1..0=3
-blt     bimm12hi rs1 rs2 bimm12lo 14..12=4 6..2=0x18 1..0=3
-bge     bimm12hi rs1 rs2 bimm12lo 14..12=5 6..2=0x18 1..0=3
-bltu    bimm12hi rs1 rs2 bimm12lo 14..12=6 6..2=0x18 1..0=3
-bgeu    bimm12hi rs1 rs2 bimm12lo 14..12=7 6..2=0x18 1..0=3
-lb      rd rs1       imm12 14..12=0 6..2=0x00 1..0=3
-lh      rd rs1       imm12 14..12=1 6..2=0x00 1..0=3
-lw      rd rs1       imm12 14..12=2 6..2=0x00 1..0=3
-lbu     rd rs1       imm12 14..12=4 6..2=0x00 1..0=3
-lhu     rd rs1       imm12 14..12=5 6..2=0x00 1..0=3
-sb     imm12hi rs1 rs2 imm12lo 14..12=0 6..2=0x08 1..0=3
-sh     imm12hi rs1 rs2 imm12lo 14..12=1 6..2=0x08 1..0=3
-sw     imm12hi rs1 rs2 imm12lo 14..12=2 6..2=0x08 1..0=3
-addi    rd rs1 imm12           14..12=0 6..2=0x04 1..0=3
-slti    rd rs1 imm12           14..12=2 6..2=0x04 1..0=3
-sltiu   rd rs1 imm12           14..12=3 6..2=0x04 1..0=3
-xori    rd rs1 imm12           14..12=4 6..2=0x04 1..0=3
-ori     rd rs1 imm12           14..12=6 6..2=0x04 1..0=3
-andi    rd rs1 imm12           14..12=7 6..2=0x04 1..0=3
-add     rd rs1 rs2 31..25=0  14..12=0 6..2=0x0C 1..0=3
-sub     rd rs1 rs2 31..25=32 14..12=0 6..2=0x0C 1..0=3
-sll     rd rs1 rs2 31..25=0  14..12=1 6..2=0x0C 1..0=3
-slt     rd rs1 rs2 31..25=0  14..12=2 6..2=0x0C 1..0=3
-sltu    rd rs1 rs2 31..25=0  14..12=3 6..2=0x0C 1..0=3
-xor     rd rs1 rs2 31..25=0  14..12=4 6..2=0x0C 1..0=3
-srl     rd rs1 rs2 31..25=0  14..12=5 6..2=0x0C 1..0=3
-sra     rd rs1 rs2 31..25=32 14..12=5 6..2=0x0C 1..0=3
-or      rd rs1 rs2 31..25=0  14..12=6 6..2=0x0C 1..0=3
-and     rd rs1 rs2 31..25=0  14..12=7 6..2=0x0C 1..0=3
-fence fm pred succ rs1 14..12=0 rd 6..2=0x03 1..0=3
+lui     rd imm20 6..2=0x0D 1..0=3 ::: OPC rd, imm20
+auipc   rd imm20 6..2=0x05 1..0=3 ::: OPC rd, imm20
+jal     rd jimm20                          6..2=0x1b 1..0=3 ::: OPC rd, jimm20
+jalr    rd rs1 imm12              14..12=0 6..2=0x19 1..0=3 ::: OPC rd, imm12(rs1)
+beq     bimm12hi rs1 rs2 bimm12lo 14..12=0 6..2=0x18 1..0=3 ::: OPC rs1, rs2, bimm12
+bne     bimm12hi rs1 rs2 bimm12lo 14..12=1 6..2=0x18 1..0=3 ::: OPC rs1, rs2, bimm12
+blt     bimm12hi rs1 rs2 bimm12lo 14..12=4 6..2=0x18 1..0=3 ::: OPC rs1, rs2, bimm12
+bge     bimm12hi rs1 rs2 bimm12lo 14..12=5 6..2=0x18 1..0=3 ::: OPC rs1, rs2, bimm12
+bltu    bimm12hi rs1 rs2 bimm12lo 14..12=6 6..2=0x18 1..0=3 ::: OPC rs1, rs2, bimm12
+bgeu    bimm12hi rs1 rs2 bimm12lo 14..12=7 6..2=0x18 1..0=3 ::: OPC rs1, rs2, bimm12
+lb      rd rs1       imm12 14..12=0 6..2=0x00 1..0=3 ::: OPC rd, imm12(rs1)
+lh      rd rs1       imm12 14..12=1 6..2=0x00 1..0=3 ::: OPC rd, imm12(rs1)
+lw      rd rs1       imm12 14..12=2 6..2=0x00 1..0=3 ::: OPC rd, imm12(rs1)
+lbu     rd rs1       imm12 14..12=4 6..2=0x00 1..0=3 ::: OPC rd, imm12(rs1)
+lhu     rd rs1       imm12 14..12=5 6..2=0x00 1..0=3 ::: OPC rd, imm12(rs1)
+sb     imm12hi rs1 rs2 imm12lo 14..12=0 6..2=0x08 1..0=3 ::: OPC rs2, imm12(rs1)
+sh     imm12hi rs1 rs2 imm12lo 14..12=1 6..2=0x08 1..0=3 ::: OPC rs2, imm12(rs1)
+sw     imm12hi rs1 rs2 imm12lo 14..12=2 6..2=0x08 1..0=3 ::: OPC rs2, imm12(rs1)
+addi    rd rs1 imm12           14..12=0 6..2=0x04 1..0=3 ::: OPC rd, rs1, imm12
+slti    rd rs1 imm12           14..12=2 6..2=0x04 1..0=3 ::: OPC rd, rs1, imm12
+sltiu   rd rs1 imm12           14..12=3 6..2=0x04 1..0=3 ::: OPC rd, rs1, imm12
+xori    rd rs1 imm12           14..12=4 6..2=0x04 1..0=3 ::: OPC rd, rs1, imm12
+ori     rd rs1 imm12           14..12=6 6..2=0x04 1..0=3 ::: OPC rd, rs1, imm12
+andi    rd rs1 imm12           14..12=7 6..2=0x04 1..0=3 ::: OPC rd, rs1, imm12
+add     rd rs1 rs2 31..25=0  14..12=0 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+sub     rd rs1 rs2 31..25=32 14..12=0 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+sll     rd rs1 rs2 31..25=0  14..12=1 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+slt     rd rs1 rs2 31..25=0  14..12=2 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+sltu    rd rs1 rs2 31..25=0  14..12=3 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+xor     rd rs1 rs2 31..25=0  14..12=4 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+srl     rd rs1 rs2 31..25=0  14..12=5 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+sra     rd rs1 rs2 31..25=32 14..12=5 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+or      rd rs1 rs2 31..25=0  14..12=6 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+and     rd rs1 rs2 31..25=0  14..12=7 6..2=0x0C 1..0=3 ::: OPC rd, rs1, rs2
+fence fm pred succ rs1 14..12=0 rd 6..2=0x03 1..0=3 ::: OPC
 #specialized fences
-$pseudo_op rv_i::fence fence.tso 31..28=8 27..24=3 23..20=3 rs1 14..12=0 rd 6..2=0x03 1..0=3
-$pseudo_op rv_i::fence pause     31..28=0 27..24=1 23..20=0 19..15=0      14..12=0 11..7=0      6..2=0x03 1..0=3
-ecall    31..20=0x000 19..7=0 6..2=0x1C 1..0=3
-ebreak   31..20=0x001 19..7=0 6..2=0x1C 1..0=3
+$pseudo_op rv_i::fence fence.tso 31..28=8 27..24=3 23..20=3 rs1 14..12=0 rd 6..2=0x03 1..0=3 ::: OPC
+$pseudo_op rv_i::fence pause     31..28=0 27..24=1 23..20=0 19..15=0      14..12=0 11..7=0      6..2=0x03 1..0=3 ::: OPC
+ecall    31..20=0x000 19..7=0 6..2=0x1C 1..0=3 ::: OPC
+ebreak   31..20=0x001 19..7=0 6..2=0x1C 1..0=3 ::: OPC
 
 #Old names for ecall/ebreak
-$pseudo_op rv_i::ecall scall     11..7=0 19..15=0 31..20=0x000 14..12=0 6..2=0x1C 1..0=3
-$pseudo_op rv_i::ebreak sbreak    11..7=0 19..15=0 31..20=0x001 14..12=0 6..2=0x1C 1..0=3
+$pseudo_op rv_i::ecall scall     11..7=0 19..15=0 31..20=0x000 14..12=0 6..2=0x1C 1..0=3 ::: OPC
+$pseudo_op rv_i::ebreak sbreak    11..7=0 19..15=0 31..20=0x001 14..12=0 6..2=0x1C 1..0=3 ::: OPC
 


### PR DESCRIPTION
Projects like [Microprobe](https://github.com/IBM/microprobe) require a complete description of the ISA to generate valid assembly.

This RFC proposes a way to specify the assembly format of an instruction for machine consumption. This approach is inspired by [Microprobe's riscv representation](https://github.com/IBM/microprobe/blob/master/targets/riscv/isa/riscv-common/instruction_format.yaml).

If there is an interest/desire to add this to riscv-opcodes I'd be happy to iterate on the format and contribute to adding this for all extensions.