### PR TITLE
Add exception xtval codes of shadow stack access fault

### DIFF
--- a/encoding.h
+++ b/encoding.h
@@ -343,6 +343,7 @@
 
 /* software check exception xtval codes */
 #define LANDING_PAD_FAULT 2
+#define SHADOW_STACK_FAULT 3
 
 #ifdef __riscv
 


### PR DESCRIPTION
Add SHADW_STACK_FAULT exception xtval code which used in https://github.com/riscv-software-src/riscv-isa-sim/pull/1560#
Correct the mistake of forgetting to update riscv-opcodes.