### PR TITLE
Include rs1 values in Go instruction opcodes.

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -941,6 +941,7 @@ import "cmd/internal/obj"
 type inst struct {
 	opcode uint32
 	funct3 uint32
+	rs1    uint32
 	rs2    uint32
 	csr    int64
 	funct7 uint32
@@ -960,11 +961,12 @@ func encode(a obj.As) *inst {
         enc_match = int(instr_dict[i]['match'],0)
         opcode = (enc_match >> 0) & ((1<<7)-1)
         funct3 = (enc_match >> 12) & ((1<<3)-1)
+        rs1 = (enc_match >> 15) & ((1<<5)-1)
         rs2 = (enc_match >> 20) & ((1<<5)-1)
         csr = (enc_match >> 20) & ((1<<12)-1)
         funct7 = (enc_match >> 25) & ((1<<7)-1)
         instr_str += f'''  case A{i.upper().replace("_","")}:
-    return &inst{{ {hex(opcode)}, {hex(funct3)}, {hex(rs2)}, {signed(csr,12)}, {hex(funct7)} }}
+    return &inst{{ {hex(opcode)}, {hex(funct3)}, {hex(rs1)}, {hex(rs2)}, {signed(csr,12)}, {hex(funct7)} }}
 '''
         
     with open('inst.go','w') as file:


### PR DESCRIPTION
Some of the instructions in the V extension encode part of the opcode in the rs1 field. These values are not currently included in the Go instruction opcodes - fix this by adding an rs1 field and populating it with the relevant values.