### PR TITLE
Add double trap to causes.csv

### DIFF
--- a/causes.csv
+++ b/causes.csv
@@ -13,6 +13,7 @@
 0x0C, "fetch page fault"
 0x0D, "load page fault"
 0x0F, "store page fault"
+0x10, "double trap"
 0x12, "software check fault"
 0x13, "hardware error fault"
 0x14, "fetch guest page fault"


### PR DESCRIPTION
A recent Spike commit requires the double trap definition (https://github.com/riscv-software-src/riscv-isa-sim/pull/1700).

I cannot find the definition while updating the encoding.h, and, thus, create this commit.

@ved-rivos would you mind having a review on this commit?