### PR TITLE
Vector crypto additional extensions: Zvbc32e and Zvkgs

### DIFF
--- a/rv_zvbc
+++ b/rv_zvbc
@@ -1,4 +1,4 @@
-# Zvbc - Vector Carryless Multiplication
+# Zvbc/Zvbce32 - Vector Carryless Multiplication
 
 # Carryless Multiply
 vclmul.vv    31..26=0x0C         vm vs2 vs1     14..12=0x2 vd 6..0=0x57

--- a/unratified/rv_zvkgs
+++ b/unratified/rv_zvkgs
@@ -1,0 +1,8 @@
+# Zvkgs - Vector-Scalar GCM/GMAC
+
+# Vector Multiply over GHASH Galois-Field
+vgmul.vs 31..26=0x29 25=1 vs2 19..15=0x11 14..12=0x2 vd 6..0=0x77
+
+# Vector Add-Multiply over GHASH Galois-Field
+vghsh.vs 31..26=0x23 25=1 vs2 vs1 14..12=0x2 vd 6..0=0x77
+


### PR DESCRIPTION
Preparation for vector crypto fast track proposal

- Adding opcodes for Zvkgs (vector-scalar GHASH) instructions: vghsh.vs and vgmul.vs
- Adding mention of Zvbc32e extension in Zvbc opcode section

Extension proposal is track by a PR on `riscv-isa-manual`: https://github.com/riscv/riscv-isa-manual/pull/1306.