### PR TITLE
Move F extension CSRs to the rv_f

### DIFF
--- a/rv_f
+++ b/rv_f
@@ -29,3 +29,12 @@ fmv.w.x   rd rs1 24..20=0 31..27=0x1E 14..12=0 26..25=0 6..2=0x14 1..0=3
 $pseudo_op rv_f::fmv.x.w fmv.x.s   rd rs1 24..20=0 31..27=0x1C 14..12=0 26..25=0 6..2=0x14 1..0=3
 $pseudo_op rv_f::fmv.w.x fmv.s.x   rd rs1 24..20=0 31..27=0x1E 14..12=0 26..25=0 6..2=0x14 1..0=3
 
+#CSRs
+$pseudo_op rv_zicsr::csrrs  frflags    rd 19..15=0 31..20=0x001 14..12=2 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrw  fsflags    rd rs1      31..20=0x001 14..12=1 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrwi fsflagsi   rd zimm     31..20=0x001 14..12=5 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrs  frrm       rd 19..15=0 31..20=0x002 14..12=2 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrw  fsrm       rd rs1      31..20=0x002 14..12=1 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrwi fsrmi      rd zimm     31..20=0x002 14..12=5 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrw  fscsr      rd rs1      31..20=0x003 14..12=1 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrs  frcsr      rd 19..15=0 31..20=0x003 14..12=2 6..2=0x1C 1..0=3

--- a/rv_zicsr
+++ b/rv_zicsr
@@ -4,14 +4,3 @@ csrrc     rd rs1 csr        14..12=3 6..2=0x1C 1..0=3
 csrrwi    rd csr zimm       14..12=5 6..2=0x1C 1..0=3
 csrrsi    rd csr zimm       14..12=6 6..2=0x1C 1..0=3
 csrrci    rd csr zimm       14..12=7 6..2=0x1C 1..0=3
-
-$pseudo_op rv_zicsr::csrrs  frflags    rd 19..15=0 31..20=0x001 14..12=2 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrw  fsflags    rd rs1      31..20=0x001 14..12=1 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrwi fsflagsi   rd zimm     31..20=0x001 14..12=5 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrs  frrm       rd 19..15=0 31..20=0x002 14..12=2 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrw  fsrm       rd rs1      31..20=0x002 14..12=1 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrwi fsrmi      rd zimm     31..20=0x002 14..12=5 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrw  fscsr      rd rs1      31..20=0x003 14..12=1 6..2=0x1C 1..0=3
-$pseudo_op rv_zicsr::csrrs  frcsr      rd 19..15=0 31..20=0x003 14..12=2 6..2=0x1C 1..0=3
-
-


### PR DESCRIPTION
As mentioned in #275, this PR moves "F" extension pseudo-ops that were in the rv_zicsr to rv_f