### PR TITLE
Added the rest of 1:1 PseudoInstructions

### DIFF
--- a/rv_i
+++ b/rv_i
@@ -70,3 +70,7 @@ $pseudo_op rv_i::sltu   snez rd rs2 31..25=0 19..15=0x0 14..12=3 6..2=0x0C 1..0=
 $pseudo_op rv_i::slt    sltz rd rs1 31..25=0 24..20=0x0 14..12=2 6..2=0x0C 1..0=3
 $pseudo_op rv_i::slt    sgtz rd rs2 31..25=0 19..15=0x0 14..12=2 6..2=0x0C 1..0=3
 
+$pseudo_op rv_i::jalr   jalr rs1    31..20=0 14..12=0 11..7=0x01 6..2=0x19 1..0=3
+$pseudo_op rv_i::jalr   jr   rs1    31..20=0 14..12=0 11..7=0x0  6..2=0x19 1..0=3
+$pseudo_op rv_i::jal    jal  jimm20                   11..7=0x01 6..2=0x1b 1..0=3
+$pseudo_op rv_i::jal    j    jimm20                   11..7=0x0  6..2=0x1b 1..0=3

--- a/rv_zicsr
+++ b/rv_zicsr
@@ -1,6 +1,15 @@
-csrrw     rd rs1 csr 14..12=1 6..2=0x1C 1..0=3
+csrrw     rd rs1 csr        14..12=1 6..2=0x1C 1..0=3
 csrrs     rd rs1 csr        14..12=2 6..2=0x1C 1..0=3
 csrrc     rd rs1 csr        14..12=3 6..2=0x1C 1..0=3
 csrrwi    rd csr zimm       14..12=5 6..2=0x1C 1..0=3
 csrrsi    rd csr zimm       14..12=6 6..2=0x1C 1..0=3
 csrrci    rd csr zimm       14..12=7 6..2=0x1C 1..0=3
+
+#pseudoinstructions
+$pseudo_op rv_zicsr::csrrs csrr     rd csr      19..15=0x0 14..12=2 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrw csrw     rs1 csr     14..12=1 11..7=0x0 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrs csrs     rs1 csr     14..12=2 11..7=0x0 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrc csrc     rs1 csr     14..12=3 11..7=0x0 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrwi csrwi   csr zimm    14..12=5 11..7=0x0 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrsi csrsi   csr zimm    14..12=6 11..7=0x0 6..2=0x1C 1..0=3
+$pseudo_op rv_zicsr::csrrci csrci   csr zimm    14..12=7 11..7=0x0 6..2=0x1C 1..0=3


### PR DESCRIPTION
Complementing #277, there were a few 1:1 pseudo instructions that were missing.
Below is the list with the link to the asm manual:

# I 
[j](https://github.com/riscv-non-isa/riscv-asm-manual/blob/f8bcdded42ac9108e0bf7cf0789dbe306ec329e2/riscv-asm.md?plain=1#L961)
[jal ](https://github.com/riscv-non-isa/riscv-asm-manual/blob/f8bcdded42ac9108e0bf7cf0789dbe306ec329e2/riscv-asm.md?plain=1#L962)
[jr](https://github.com/riscv-non-isa/riscv-asm-manual/blob/f8bcdded42ac9108e0bf7cf0789dbe306ec329e2/riscv-asm.md?plain=1#L963)
[jalr ](https://github.com/riscv-non-isa/riscv-asm-manual/blob/f8bcdded42ac9108e0bf7cf0789dbe306ec329e2/riscv-asm.md?plain=1#L964)

# Zicsr
[csrr](https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_zicsr#L9) 
[csrw](https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_zicsr#L10)
[csrs](https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_zicsr#L11)
[csrc](https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_zicsr#L12)
[csrwi](https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_zicsr#L13)
[csrsi](https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_zicsr#L14)
[csrci](https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_zicsr#L15)