### PR TITLE
Added Pseudo-instructions from F and D. Allow for instructions to have a special field.

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -116,9 +116,7 @@ def process_enc_line(line, ext):
             if len(parts := a.split('=')) == 2:
                 existing_arg, new_arg = parts
                 if existing_arg in arg_lut:
-                    print ("old",arg_lut)
                     arg_lut[a] = arg_lut[existing_arg]
-                    print ("new\n", arg_lut)
                 
                 else:
                     logging.error(f' Found field {existing_arg} in variable {a} in instruction {name} whose mapping in arg_lut does not exist')
@@ -380,11 +378,16 @@ def create_inst_dict(file_filter, include_pseudo=False, include_pseudo_ops=[]):
                     instr_dict[name] = single_dict
                     logging.debug(f'        including pseudo_ops:{name}')
                 else:
+                    if(single_dict['match'] != instr_dict[name]['match']):
+                        instr_dict[name + '_pseudo'] = single_dict
+
                     # if a pseudo instruction has already been added to the filtered
                     # instruction dictionary but the extension is not in the current
                     # list, add it
-                    ext_name = single_dict['extension']
-                    if ext_name not in instr_dict[name]['extension']:
+                    else:
+                        ext_name = single_dict['extension']
+
+                    if (ext_name not in instr_dict[name]['extension']) & (name + '_pseudo' not in instr_dict):
                         instr_dict[name]['extension'].extend(ext_name)
             else:
                 logging.debug(f'        Skipping pseudo_op {pseudo_inst} since original instruction {orig_inst} already selected in list')

--- a/parse.py
+++ b/parse.py
@@ -113,16 +113,27 @@ def process_enc_line(line, ext):
     encoding_args = encoding.copy()
     for a in args:
         if a not in arg_lut:
-            logging.error(f' Found variable {a} in instruction {name} whose mapping in arg_lut does not exist')
-            raise SystemExit(1)
-        else:
-            (msb, lsb) = arg_lut[a]
-            for ind in range(lsb, msb + 1):
-                # overlapping bits
-                if encoding_args[31 - ind] != '-':
-                    logging.error(f' Found variable {a} in instruction {name} overlapping {encoding_args[31 - ind]} variable in bit {ind}')
+            if len(parts := a.split('=')) == 2:
+                existing_arg, new_arg = parts
+                if existing_arg in arg_lut:
+                    print ("old",arg_lut)
+                    arg_lut[a] = arg_lut[existing_arg]
+                    print ("new\n", arg_lut)
+                
+                else:
+                    logging.error(f' Found field {existing_arg} in variable {a} in instruction {name} whose mapping in arg_lut does not exist')
                     raise SystemExit(1)
-                encoding_args[31 - ind] = a
+            else:
+                logging.error(f' Found variable {a} in instruction {name} whose mapping in arg_lut does not exist')
+                raise SystemExit(1)
+        (msb, lsb) = arg_lut[a]
+        for ind in range(lsb, msb + 1):
+            # overlapping bits
+            if encoding_args[31 - ind] != '-':
+                logging.error(f' Found variable {a} in instruction {name} overlapping {encoding_args[31 - ind]} variable in bit {ind}')
+                raise SystemExit(1)
+            encoding_args[31 - ind] = a
+
 
     # update the fields of the instruction as a dict and return back along with
     # the name of the instruction

--- a/rv_d
+++ b/rv_d
@@ -24,3 +24,9 @@ fcvt.w.d  rd rs1 24..20=0 31..27=0x18 rm       26..25=1 6..2=0x14 1..0=3
 fcvt.wu.d rd rs1 24..20=1 31..27=0x18 rm       26..25=1 6..2=0x14 1..0=3
 fcvt.d.w  rd rs1 24..20=0 31..27=0x1A rm       26..25=1 6..2=0x14 1..0=3
 fcvt.d.wu rd rs1 24..20=1 31..27=0x1A rm       26..25=1 6..2=0x14 1..0=3
+
+#pseudoinstructions
+$pseudo_op rv_d::fsgnj.d  fmv.d  rd rs1 rs2=rs1 31..27=0x04 14..12=0 26..25=1 6..2=0x14 1..0=3
+$pseudo_op rv_d::fsgnjx.d fabs.d rd rs1 rs2=rs1 31..27=0x04 14..12=2 26..25=1 6..2=0x14 1..0=3
+$pseudo_op rv_d::fsgnjn.d fneg.d rd rs1 rs2=rs1 31..27=0x04 14..12=1 26..25=1 6..2=0x14 1..0=3
+ 

--- a/rv_d
+++ b/rv_d
@@ -30,3 +30,4 @@ $pseudo_op rv_d::fsgnj.d  fmv.d  rd rs1 rs2=rs1 31..27=0x04 14..12=0 26..25=1 6.
 $pseudo_op rv_d::fsgnjx.d fabs.d rd rs1 rs2=rs1 31..27=0x04 14..12=2 26..25=1 6..2=0x14 1..0=3
 $pseudo_op rv_d::fsgnjn.d fneg.d rd rs1 rs2=rs1 31..27=0x04 14..12=1 26..25=1 6..2=0x14 1..0=3
  
+ 

--- a/rv_f
+++ b/rv_f
@@ -29,6 +29,11 @@ fmv.w.x   rd rs1 24..20=0 31..27=0x1E 14..12=0 26..25=0 6..2=0x14 1..0=3
 $pseudo_op rv_f::fmv.x.w fmv.x.s   rd rs1 24..20=0 31..27=0x1C 14..12=0 26..25=0 6..2=0x14 1..0=3
 $pseudo_op rv_f::fmv.w.x fmv.s.x   rd rs1 24..20=0 31..27=0x1E 14..12=0 26..25=0 6..2=0x14 1..0=3
 
+#pseudointructions
+$pseudo_op rv_f::fsgnj.s  fmv.s   rd rs1 rs2=rs1 31..27=0x04 14..12=0 26..25=0 6..2=0x14 1..0=3
+$pseudo_op rv_f::fsgnjx.s fabs.s  rd rs1 rs2=rs1 31..27=0x04 14..12=2 26..25=0 6..2=0x14 1..0=3
+$pseudo_op rv_f::fsgnjn.s fneg.s  rd rs1 rs2=rs1 31..27=0x04 14..12=1 26..25=0 6..2=0x14 1..0=3
+
 #CSRs
 $pseudo_op rv_zicsr::csrrs  frflags    rd 19..15=0 31..20=0x001 14..12=2 6..2=0x1C 1..0=3
 $pseudo_op rv_zicsr::csrrw  fsflags    rd rs1      31..20=0x001 14..12=1 6..2=0x1C 1..0=3

--- a/rv_f
+++ b/rv_f
@@ -43,3 +43,4 @@ $pseudo_op rv_zicsr::csrrw  fsrm       rd rs1      31..20=0x002 14..12=1 6..2=0x
 $pseudo_op rv_zicsr::csrrwi fsrmi      rd zimm     31..20=0x002 14..12=5 6..2=0x1C 1..0=3
 $pseudo_op rv_zicsr::csrrw  fscsr      rd rs1      31..20=0x003 14..12=1 6..2=0x1C 1..0=3
 $pseudo_op rv_zicsr::csrrs  frcsr      rd 19..15=0 31..20=0x003 14..12=2 6..2=0x1C 1..0=3
+

--- a/rv_q
+++ b/rv_q
@@ -26,3 +26,10 @@ fcvt.w.q  rd rs1 24..20=0 31..27=0x18 rm       26..25=3 6..2=0x14 1..0=3
 fcvt.wu.q rd rs1 24..20=1 31..27=0x18 rm       26..25=3 6..2=0x14 1..0=3
 fcvt.q.w  rd rs1 24..20=0 31..27=0x1A rm       26..25=3 6..2=0x14 1..0=3
 fcvt.q.wu rd rs1 24..20=1 31..27=0x1A rm       26..25=3 6..2=0x14 1..0=3
+
+
+#pseudoinstructions
+$pseudo_op rv_q::fsgnj.q  fmv.q  rd rs1 rs2=rs1 31..27=0x04 14..12=0 26..25=3 6..2=0x14 1..0=3
+$pseudo_op rv_q::fsgnjx.q fabs.q rd rs1 rs2=rs1 31..27=0x04 14..12=2 26..25=3 6..2=0x14 1..0=3
+$pseudo_op rv_q::fsgnjn.q fneg.q rd rs1 rs2=rs1 31..27=0x04 14..12=1 26..25=3 6..2=0x14 1..0=3
+

--- a/rv_zfh
+++ b/rv_zfh
@@ -28,3 +28,8 @@ fcvt.h.w  rd rs1 24..20=0 31..27=0x1A rm       26..25=2 6..2=0x14 1..0=3
 fcvt.h.wu rd rs1 24..20=1 31..27=0x1A rm       26..25=2 6..2=0x14 1..0=3
 fmv.h.x   rd rs1 24..20=0 31..27=0x1E 14..12=0 26..25=2 6..2=0x14 1..0=3
 
+#pseudoinstructions
+$pseudo_op rv_zfh::fsgnj.h  fmv.h  rd rs1 rs2=rs1 31..27=0x04 14..12=0 26..25=2 6..2=0x14 1..0=3
+$pseudo_op rv_zfh::fsgnjx.h fabs.h rd rs1 rs2=rs1 31..27=0x04 14..12=2 26..25=2 6..2=0x14 1..0=3
+$pseudo_op rv_zfh::fsgnjn.h fneg.h rd rs1 rs2=rs1 31..27=0x04 14..12=1 26..25=2 6..2=0x14 1..0=3
+


### PR DESCRIPTION
This time there was a need to modify parse.py a tiny bit in order to fully accommodate all pseudo-instructions.
Since parse.py did not allow to have pseudoinstructions with the two of the same register(e.g. fmv_s rs, rs) due to how it parses, I created a work around, that I succesfully checked does not break any of the pre-existing instructions. It allows that a register is equalled to anything, as in, "rs2=rs1" and uses the "rs2" to know it's position in encoding.

Adittionally, I added the following pseudo-instructions:
# F 
[fmv.s](
https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_f#L33) 
[fabs.s](
https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_f#L34) 
[fneg.s](
https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_f#L35)
 
# D 
[fmv.d](
https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_d#L29)
[fabs.d](
https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_d#L30) 
[fneg.d](
https://github.com/foss-for-synopsys-dwc-arc-processors/riscv-opcodes/blob/436c27e1607f56e23919179218d212ee1b6716d8/rv_d#L31)