### PR TITLE
ci: use riscv-builders

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,20 +8,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: riscv-builders
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
     - name: Install PyYAML
       run: |
-        pip3 install -r requirements.txt
-        pip3 install coverage
+        apt install -yq python3-pip
+        pip config set global.break-system-packages true
+        pip install -r requirements.txt
+        pip install coverage
     - name: Run pre-commit
       run: |
-        python3 -m pip install pre-commit
+        pip install pre-commit
         pre-commit run --all-files
     - name: Generate
       run: coverage run ./parse.py -c -chisel -sverilog -rust -latex -spinalhdl -go "rv*" "unratified/rv*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,17 +8,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: riscv-builders
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
     - name: Install PyYAML
       run: |
-         pip3 install -r requirements.txt
-         pip3 install coverage
+         apt install -yq python3-pip
+         pip config set global.break-system-packages true
+         pip install --break-system-packages -r requirements.txt
+         pip install coverage
     - name: Test error outputs
       run: coverage run -m unittest -b
     - name: Generate coverage


### PR DESCRIPTION
To runs with riscv-builders, we need to install Github App
https://github.com/apps/riscv-builders

![image](https://github.com/user-attachments/assets/def812e2-acf7-4868-865c-dacffb023506)


p.s It takes 9m to complete the CI, although it's ~30s with x86
