### PR TITLE
Stop including pseudo instructions in output for Go

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -1199,13 +1199,14 @@ if __name__ == "__main__":
     print(f"Running with args : {sys.argv}")
 
     extensions = sys.argv[1:]
-    for i in ["-c", "-latex", "-chisel", "-sverilog", "-rust", "-go", "-spinalhdl"]:
+    for i in ["-c", "-chisel", "-go", "-latex", "-pseudo" "-rust", "-spinalhdl", "-sverilog"]:
         if i in extensions:
             extensions.remove(i)
     print(f"Extensions selected : {extensions}")
 
     include_pseudo = False
-    if "-go" in sys.argv[1:]:
+
+    if "-pseudo" in sys.argv[1:]:
         include_pseudo = True
 
     instr_dict = create_inst_dict(extensions, include_pseudo)

--- a/parse.py
+++ b/parse.py
@@ -1199,7 +1199,16 @@ if __name__ == "__main__":
     print(f"Running with args : {sys.argv}")
 
     extensions = sys.argv[1:]
-    for i in ["-c", "-chisel", "-go", "-latex", "-pseudo" "-rust", "-spinalhdl", "-sverilog"]:
+    for i in [
+        "-c",
+        "-chisel",
+        "-go",
+        "-latex",
+        "-pseudo",
+        "-rust",
+        "-spinalhdl",
+        "-sverilog",
+    ]:
         if i in extensions:
             extensions.remove(i)
     print(f"Extensions selected : {extensions}")


### PR DESCRIPTION
Go really only needs the instruction encodings for actual instructions. Additional pseudo-encodings have since been added to the riscv-opcodes generation, which also include instructions that are aliased to themselves (e.g. AJALPSEUDO/AJALRPSEUDO). Instead of dealing with these complications, stop including pseudo instructions in the output for Go and we'll synthesise the pseudo instructions that we need.

Add -pseudo which can be used to enable the generation of pseudo-instructions, restoring the previous behaviour.

Fixes #286 