### PR TITLE
Remove wildcard imports

### DIFF
--- a/c_utils.py
+++ b/c_utils.py
@@ -2,7 +2,8 @@ import logging
 import os
 import pprint
 
-from shared_utils import *
+from constants import causes, csrs, csrs32
+from shared_utils import InstrDict, arg_lut
 
 pp = pprint.PrettyPrinter(indent=2)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:: %(message)s")

--- a/chisel_utils.py
+++ b/chisel_utils.py
@@ -1,10 +1,8 @@
 import logging
 import pprint
 
-from constants import *
-
-# from shared_utils import overlaps, overlap_allowed, extension_overlap_allowed, instruction_overlap_allowed, process_enc_line, same_base_isa, add_segmented_vls_insn, expand_nf_field
-from shared_utils import *
+from constants import causes, csrs, csrs32
+from shared_utils import InstrDict, instr_dict_2_extensions
 
 pp = pprint.PrettyPrinter(indent=2)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:: %(message)s")

--- a/go_utils.py
+++ b/go_utils.py
@@ -2,7 +2,7 @@ import logging
 import pprint
 import sys
 
-from shared_utils import *
+from shared_utils import InstrDict, signed
 
 pp = pprint.PrettyPrinter(indent=2)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:: %(message)s")

--- a/latex_utils.py
+++ b/latex_utils.py
@@ -2,8 +2,8 @@ import logging
 import pprint
 from typing import TextIO
 
-from constants import *
-from shared_utils import *
+from constants import latex_fixed_fields, latex_inst_type, latex_mapping
+from shared_utils import InstrDict, arg_lut, create_inst_dict
 
 pp = pprint.PrettyPrinter(indent=2)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:: %(message)s")

--- a/rust_utils.py
+++ b/rust_utils.py
@@ -1,10 +1,8 @@
 import logging
 import pprint
 
-from constants import *
-
-# from shared_utils import overlaps, overlap_allowed, extension_overlap_allowed, instruction_overlap_allowed, process_enc_line, same_base_isa, add_segmented_vls_insn, expand_nf_field
-from shared_utils import *
+from constants import causes, csrs, csrs32
+from shared_utils import InstrDict
 
 pp = pprint.PrettyPrinter(indent=2)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:: %(message)s")

--- a/shared_utils.py
+++ b/shared_utils.py
@@ -8,7 +8,15 @@ import re
 from itertools import chain
 from typing import Dict, TypedDict
 
-from constants import *
+from constants import (
+    arg_lut,
+    fixed_ranges,
+    imported_regex,
+    overlapping_extensions,
+    overlapping_instructions,
+    pseudo_regex,
+    single_fixed,
+)
 
 LOG_FORMAT = "%(levelname)s:: %(message)s"
 LOG_LEVEL = logging.INFO

--- a/sverilog_utils.py
+++ b/sverilog_utils.py
@@ -1,7 +1,8 @@
 import logging
 import pprint
 
-from shared_utils import *
+from constants import csrs, csrs32
+from shared_utils import InstrDict
 
 pp = pprint.PrettyPrinter(indent=2)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:: %(message)s")

--- a/test.py
+++ b/test.py
@@ -4,7 +4,25 @@ import logging
 import unittest
 from unittest.mock import Mock, patch
 
-from shared_utils import *
+from shared_utils import (
+    InstrDict,
+    check_arg_lut,
+    check_overlapping_bits,
+    extract_isa_type,
+    find_extension_file,
+    handle_arg_lut_mapping,
+    initialize_encoding,
+    is_rv_variant,
+    overlaps,
+    pad_to_equal_length,
+    parse_instruction_line,
+    process_enc_line,
+    process_fixed_ranges,
+    process_standard_instructions,
+    same_base_isa,
+    update_encoding_for_fixed_range,
+    validate_bit_range,
+)
 
 
 class EncodingUtilsTest(unittest.TestCase):


### PR DESCRIPTION
Use explicit imports rather than wildcards. This is more maintainable.
