### PR TITLE
Update the versions of all GitHub Actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12','3.13']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -40,4 +40,4 @@ jobs:
       run: coverage xml
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12','3.13']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -31,4 +31,4 @@ jobs:
       run: coverage xml
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4


### PR DESCRIPTION
Update the versions of all GitHub Actions, as the old ones are using Node 12, which is deprecated.