### PR TITLE
Use argparse for argument parsing

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
+
+import argparse
 import collections
 import json
 import logging
 import pprint
-import sys
 
 from c_utils import make_c
 from chisel_utils import make_chisel
@@ -21,34 +22,24 @@ pretty_printer = pprint.PrettyPrinter(indent=2)
 logging.basicConfig(level=LOG_LEVEL, format=LOG_FORMAT)
 
 
-def main():
-    print(f"Running with args : {sys.argv}")
-
-    extensions = sys.argv[1:]
-
-    targets = {
-        "-c",
-        "-chisel",
-        "-go",
-        "-latex",
-        "-pseudo",
-        "-rust",
-        "-spinalhdl",
-        "-sverilog",
-    }
-
-    extensions = [ext for ext in extensions if ext not in targets]
-    print(f"Extensions selected : {extensions}")
-
-    include_pseudo = "-pseudo" in sys.argv[1:]
-
+def generate_extensions(
+    extensions: list[str],
+    include_pseudo: bool,
+    c: bool,
+    chisel: bool,
+    spinalhdl: bool,
+    sverilog: bool,
+    rust: bool,
+    go: bool,
+    latex: bool,
+):
     instr_dict = create_inst_dict(extensions, include_pseudo)
 
     with open("instr_dict.json", "w", encoding="utf-8") as outfile:
         json.dump(add_segmented_vls_insn(instr_dict), outfile, indent=2)
     instr_dict = collections.OrderedDict(sorted(instr_dict.items()))
 
-    if "-c" in sys.argv[1:]:
+    if c:
         instr_dict_c = create_inst_dict(
             extensions, False, include_pseudo_ops=emitted_pseudo_ops
         )
@@ -56,31 +47,72 @@ def main():
         make_c(instr_dict_c)
         logging.info("encoding.out.h generated successfully")
 
-    if "-chisel" in sys.argv[1:]:
+    if chisel:
         make_chisel(instr_dict)
         logging.info("inst.chisel generated successfully")
 
-    if "-spinalhdl" in sys.argv[1:]:
+    if spinalhdl:
         make_chisel(instr_dict, True)
         logging.info("inst.spinalhdl generated successfully")
 
-    if "-sverilog" in sys.argv[1:]:
+    if sverilog:
         make_sverilog(instr_dict)
         logging.info("inst.sverilog generated successfully")
 
-    if "-rust" in sys.argv[1:]:
+    if rust:
         make_rust(instr_dict)
         logging.info("inst.rs generated successfully")
 
-    if "-go" in sys.argv[1:]:
+    if go:
         make_go(instr_dict)
         logging.info("inst.go generated successfully")
 
-    if "-latex" in sys.argv[1:]:
+    if latex:
         make_latex_table()
         logging.info("instr-table.tex generated successfully")
         make_priv_latex_table()
         logging.info("priv-instr-table.tex generated successfully")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate RISC-V constants headers")
+    parser.add_argument(
+        "-pseudo", action="store_true", help="Include pseudo-instructions"
+    )
+    parser.add_argument("-c", action="store_true", help="Generate output for C")
+    parser.add_argument(
+        "-chisel", action="store_true", help="Generate output for Chisel"
+    )
+    parser.add_argument(
+        "-spinalhdl", action="store_true", help="Generate output for SpinalHDL"
+    )
+    parser.add_argument(
+        "-sverilog", action="store_true", help="Generate output for SystemVerilog"
+    )
+    parser.add_argument("-rust", action="store_true", help="Generate output for Rust")
+    parser.add_argument("-go", action="store_true", help="Generate output for Go")
+    parser.add_argument("-latex", action="store_true", help="Generate output for Latex")
+    parser.add_argument(
+        "extensions",
+        nargs="*",
+        help="Extensions to use. This is a glob of the rv_.. files, e.g. 'rv*' will give all extensions.",
+    )
+
+    args = parser.parse_args()
+
+    print(f"Extensions selected : {args.extensions}")
+
+    generate_extensions(
+        args.extensions,
+        args.pseudo,
+        args.c,
+        args.chisel,
+        args.spinalhdl,
+        args.sverilog,
+        args.rust,
+        args.go,
+        args.latex,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is more maintainable and scalable and gives better errors and a nice `--help` message. The interface is compatible with the previous version.