### PR TITLE
Sort JSON output

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import collections
+
 import json
 import logging
 import pprint
@@ -43,16 +43,16 @@ def main():
     include_pseudo = "-pseudo" in sys.argv[1:]
 
     instr_dict = create_inst_dict(extensions, include_pseudo)
+    instr_dict = dict(sorted(instr_dict.items()))
 
     with open("instr_dict.json", "w", encoding="utf-8") as outfile:
         json.dump(add_segmented_vls_insn(instr_dict), outfile, indent=2)
-    instr_dict = collections.OrderedDict(sorted(instr_dict.items()))
 
     if "-c" in sys.argv[1:]:
         instr_dict_c = create_inst_dict(
             extensions, False, include_pseudo_ops=emitted_pseudo_ops
         )
-        instr_dict_c = collections.OrderedDict(sorted(instr_dict_c.items()))
+        instr_dict_c = dict(sorted(instr_dict_c.items()))
         make_c(instr_dict_c)
         logging.info("encoding.out.h generated successfully")
 


### PR DESCRIPTION
If we're sorting the dictionary anyway we may as well output the JSON sorted.

Also since Python 3.6 we can just use `dict()` since the insertion order is preserved.