### PR TITLE
Add CSR encodings for Go and remove call to Go fmt

### DIFF
--- a/go_utils.py
+++ b/go_utils.py
@@ -2,6 +2,7 @@ import logging
 import pprint
 import sys
 
+from constants import csrs
 from shared_utils import InstrDict, signed
 
 pp = pprint.PrettyPrinter(indent=2)
@@ -31,9 +32,14 @@ func encode(a obj.As) *inst {
 	switch a {
 """
 
-    endoffile = """  }
+    csrs_map_str = """  }
 	return nil
 }
+
+var csrs = map[uint16]string {
+"""
+
+    endoffile = """}
 """
 
     instr_str = ""
@@ -48,8 +54,11 @@ func encode(a obj.As) *inst {
         instr_str += f"""  case A{i.upper().replace("_","")}:
     return &inst{{ {hex(opcode)}, {hex(funct3)}, {hex(rs1)}, {hex(rs2)}, {signed(csr,12)}, {hex(funct7)} }}
 """
+    for num, name in sorted(csrs, key=lambda row: row[0]):
+        csrs_map_str += f'{hex(num)} : "{name.upper()}",\n'
 
     with open("inst.go", "w", encoding="utf-8") as file:
         file.write(prelude)
         file.write(instr_str)
+        file.write(csrs_map_str)
         file.write(endoffile)

--- a/go_utils.py
+++ b/go_utils.py
@@ -1,6 +1,5 @@
 import logging
 import pprint
-import subprocess
 import sys
 
 from shared_utils import InstrDict, signed
@@ -54,8 +53,3 @@ func encode(a obj.As) *inst {
         file.write(prelude)
         file.write(instr_str)
         file.write(endoffile)
-
-    try:
-        subprocess.run(["go", "fmt", "inst.go"], check=True)
-    except:  # pylint: disable=bare-except
-        pass


### PR DESCRIPTION
This PR updates go_utils.py so that it generates a map of CSR numbers to CSR names.  It also removes the call to go fmt in go_utils.py which doesn't work and always generates an error.

An example of what the new inst.go file looks like and how it will be used can be found in the links below

- https://go-review.googlesource.com/c/go/+/630518/2
- https://go-review.googlesource.com/c/go/+/630519/2
