### PR TITLE
replace deprecated \bf with \bfseries

### DIFF
--- a/latex_utils.py
+++ b/latex_utils.py
@@ -415,7 +415,7 @@ def make_ext_latex_table(
             content += f"""
 
 \\multicolumn{{{ilen}}}{{c}}{{}} & \\\\
-\\multicolumn{{{ilen}}}{{c}}{{\\bf {title} }} & \\\\
+\\multicolumn{{{ilen}}}{{c}}{{\\bfseries {title} }} & \\\\
 \\cline{{2-{ilen+1}}}
 
             &


### PR DESCRIPTION
`\bf` is deprecated for probably 2 decades now and doesn't work with some packages like KOMA.