### PR TITLE
Remove pseudo_op to rv64_i for slli,srli,srai

### DIFF
--- a/extensions/rv32_i
+++ b/extensions/rv32_i
@@ -1,6 +1,6 @@
-$pseudo_op rv64_i::slli slli rd rs1 shamtw 31..25=0  14..12=1 6..2=0x04 1..0=3
-$pseudo_op rv64_i::srli srli rd rs1 shamtw 31..25=0  14..12=5 6..2=0x04 1..0=3
-$pseudo_op rv64_i::srai srai rd rs1 shamtw 31..25=32 14..12=5 6..2=0x04 1..0=3
-$pseudo_op rv64_i::slli slli_rv32 rd rs1 shamtw 31..25=0  14..12=1 6..2=0x04 1..0=3
-$pseudo_op rv64_i::srli srli_rv32 rd rs1 shamtw 31..25=0  14..12=5 6..2=0x04 1..0=3
-$pseudo_op rv64_i::srai srai_rv32 rd rs1 shamtw 31..25=32 14..12=5 6..2=0x04 1..0=3
+slli rd rs1 shamtw 31..25=0  14..12=1 6..2=0x04 1..0=3
+srli rd rs1 shamtw 31..25=0  14..12=5 6..2=0x04 1..0=3
+srai rd rs1 shamtw 31..25=32 14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv32_i::slli slli_rv32 rd rs1 shamtw 31..25=0  14..12=1 6..2=0x04 1..0=3
+$pseudo_op rv32_i::srli srli_rv32 rd rs1 shamtw 31..25=0  14..12=5 6..2=0x04 1..0=3
+$pseudo_op rv32_i::srai srai_rv32 rd rs1 shamtw 31..25=32 14..12=5 6..2=0x04 1..0=3


### PR DESCRIPTION
Instructions slli,srli,srai have different bit pattern in rv32_i versus rv64_i. It is better to re-define them, and alias those `_rv32` suffix instruction to rv32_i self specification.