### PR TITLE
Fix #357 Incorrect data for zext.b

### DIFF
--- a/extensions/rv_i
+++ b/extensions/rv_i
@@ -50,7 +50,7 @@ $pseudo_op rv_i::ebreak sbreak    11..7=0 19..15=0 31..20=0x001 14..12=0 6..2=0x
 $pseudo_op rv_i::addi   mv rd rs1 31..20=0 14..12=0 6..2=0x04 1..0=3
 $pseudo_op rv_i::sub    neg rd rs1 31..25=32 24..20=0x0 14..12=0 6..2=0x0C 1..0=3
 $pseudo_op rv_i::addi   nop 31..20=0 19..15=0 14..12=0 11..7=0 6..2=0x04 1..0=3
-$pseudo_op rv_i::andi   zext.b rd rs1 31..20=0 14..12=7 6..2=0x04 1..0=3
+$pseudo_op rv_i::andi   zext.b rd rs1 31..20=0xff 14..12=7 6..2=0x04 1..0=3
 
 $pseudo_op rv_i::jalr ret 31..20=0 19..15=0x01 14..12=0 11..7=0 6..2=0x19 1..0=3
 


### PR DESCRIPTION
This fixes #357 to encode `zext.b` as `andi rd, rs, 255`.