### PR TITLE
Fix generation of encoding.out.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ everything:
 	@./parse.py  $(PSEUDO_FLAG) -c -go -chisel -sverilog -rust -latex -spinalhdl $(EXTENSIONS)
 
 encoding.out.h:
-	@./parse.py -c $(PSEUDO_FLAG) rv* unratified/rv_* unratified/rv32* unratified/rv64*
+	@./parse.py -c $(PSEUDO_FLAG) $(EXTENSIONS)
 
 inst.chisel:
 	@./parse.py -chisel $(PSEUDO_FLAG) $(EXTENSIONS)


### PR DESCRIPTION
The SVG generation in #364 broke this in a surprising way (though #364 really is not to blame).  The addition of a file in the root directory that began with `rv` caused the Make rule to glob that file, rather than passing the string `rv*` through to `parse.py`.

cc @christian-herber-nxp 