### PR TITLE
Correct parse.py example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,12 @@ If you only want a specific artifact you can use one or more of the following ta
 For example, if you want to generate the `c` based artifact with extensions as shown earlier, you can use the following command:
 
 ```bash
-./parse.py -c  EXTENSIONS='rv*_i rv*_m'
+./parse.py -c rv*_i rv*_m
 ```
 Which will print the following log:
 
 ```
-Running with args : ['./parse.py', '-c', 'EXTENSIONS=rv*_i rv*_m']
-Extensions selected : ['EXTENSIONS=rv*_i rv*_m']
+Extensions selected : ['rv*_i', 'rv*_m']
 INFO:: encoding.out.h generated successfully
 ```
 


### PR DESCRIPTION
This PR corrects the example usage of parse.py in the README.

The previous example set the extensions to use by specifying an
`EXTENSIONS` variable as a command line argument to the
script `parse.py`. This does not work, instead extensions should be
provided directly without a variable `EXTENSIONS`.

The output of the script is misleading since no extensions are actually
used if the command passes them through "EXTENSIONS"

This can be tested by running a command like

```
./parse.py -c EXTENSIONS='rv*_i rv*_m'
```

then inspecting the generated file and noticing that the extensions
were not actually used, for example by checking the MATCH_ defines.
The command:

```
`./parse.py -c rv*_i rv*_m
```

works.

I tested this on Linux using sh and bash shells with python3.13.2.