### PR TITLE
Change immediate type of select vector-immediate instructions to zimm5

### DIFF
--- a/extensions/rv_v
+++ b/extensions/rv_v
@@ -308,9 +308,9 @@ vrsub.vi       31..26=0x03 vm vs2 simm5 14..12=0x3 vd 6..0=0x57
 vand.vi        31..26=0x09 vm vs2 simm5 14..12=0x3 vd 6..0=0x57
 vor.vi         31..26=0x0a vm vs2 simm5 14..12=0x3 vd 6..0=0x57
 vxor.vi        31..26=0x0b vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vrgather.vi    31..26=0x0c vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vslideup.vi    31..26=0x0e vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vslidedown.vi  31..26=0x0f vm vs2 simm5 14..12=0x3 vd 6..0=0x57
+vrgather.vi    31..26=0x0c vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
+vslideup.vi    31..26=0x0e vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
+vslidedown.vi  31..26=0x0f vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
 
 vadc.vim       31..26=0x10 25=0 vs2 simm5 14..12=0x3 vd 6..0=0x57
 vmadc.vim      31..26=0x11 25=0 vs2 simm5 14..12=0x3 vd 6..0=0x57
@@ -326,19 +326,19 @@ vmsgt.vi       31..26=0x1f vm vs2 simm5 14..12=0x3 vd 6..0=0x57
 
 vsaddu.vi      31..26=0x20 vm vs2 simm5 14..12=0x3 vd 6..0=0x57
 vsadd.vi       31..26=0x21 vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vsll.vi        31..26=0x25 vm vs2 simm5 14..12=0x3 vd 6..0=0x57
+vsll.vi        31..26=0x25 vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
 vmv1r.v        31..26=0x27 25=1 vs2 19..15=0 14..12=0x3 vd 6..0=0x57
 vmv2r.v        31..26=0x27 25=1 vs2 19..15=1 14..12=0x3 vd 6..0=0x57
 vmv4r.v        31..26=0x27 25=1 vs2 19..15=3 14..12=0x3 vd 6..0=0x57
 vmv8r.v        31..26=0x27 25=1 vs2 19..15=7 14..12=0x3 vd 6..0=0x57
-vsrl.vi        31..26=0x28 vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vsra.vi        31..26=0x29 vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vssrl.vi       31..26=0x2a vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vssra.vi       31..26=0x2b vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vnsrl.wi       31..26=0x2c vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vnsra.wi       31..26=0x2d vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vnclipu.wi     31..26=0x2e vm vs2 simm5 14..12=0x3 vd 6..0=0x57
-vnclip.wi      31..26=0x2f vm vs2 simm5 14..12=0x3 vd 6..0=0x57
+vsrl.vi        31..26=0x28 vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
+vsra.vi        31..26=0x29 vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
+vssrl.vi       31..26=0x2a vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
+vssra.vi       31..26=0x2b vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
+vnsrl.wi       31..26=0x2c vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
+vnsra.wi       31..26=0x2d vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
+vnclipu.wi     31..26=0x2e vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
+vnclip.wi      31..26=0x2f vm vs2 zimm5 14..12=0x3 vd 6..0=0x57
 
 # OPMVV
 vredsum.vs     31..26=0x00 vm vs2 vs1 14..12=0x2 vd 6..0=0x57


### PR DESCRIPTION
According to the RISC-V unprivileged spec, the following instructions have a zero-extended immediate:

```
1.     vsll.vi
2.     vsrl.vi
3.     vsra.vi
4.     vnsrl.wi
5.     vnsra.wi
6.     vssrl.vi
7.     vssra.vi
8.     vnclipu.wi
9.     vnclip.wi
10.     vslideup.vi
11.     vslidedown.vi
12.     vrgather.vi
```