### PR TITLE
Make Rust constants public

### DIFF
--- a/src/riscv_opcodes/rust_utils.py
+++ b/src/riscv_opcodes/rust_utils.py
@@ -11,13 +11,13 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s:: %(message)s")
 def make_rust(instr_dict: InstrDict):
     mask_match_str = ""
     for i in instr_dict:
-        mask_match_str += f'const MATCH_{i.upper().replace(".","_")}: u32 = {(instr_dict[i]["match"])};\n'
-        mask_match_str += f'const MASK_{i.upper().replace(".","_")}: u32 = {(instr_dict[i]["mask"])};\n'
+        mask_match_str += f'pub const MATCH_{i.upper().replace(".","_")}: u32 = {(instr_dict[i]["match"])};\n'
+        mask_match_str += f'pub const MASK_{i.upper().replace(".","_")}: u32 = {(instr_dict[i]["mask"])};\n'
     for num, name in csrs + csrs32:
-        mask_match_str += f"const CSR_{name.upper()}: u16 = {hex(num)};\n"
+        mask_match_str += f"pub const CSR_{name.upper()}: u16 = {hex(num)};\n"
     for num, name in causes:
         mask_match_str += (
-            f'const CAUSE_{name.upper().replace(" ","_")}: u8 = {hex(num)};\n'
+            f'pub const CAUSE_{name.upper().replace(" ","_")}: u8 = {hex(num)};\n'
         )
     with open("inst.rs", "w", encoding="utf-8") as rust_file:
         rust_file.write(


### PR DESCRIPTION
This is the more flexible option. It's easy to make them all private again by just not making the module itself public. But as it is making them all public requires hacky regex replacements in the file.