### PR TITLE
ext-p : update table to v0.20

### DIFF
--- a/extensions/unratified/rv32_p
+++ b/extensions/unratified/rv32_p
@@ -10,6 +10,8 @@ $pseudo_op rv64_p::psslai.w sslai                 31=1 30..28=0x5 27=0 26..25=0x
 
 
 # Page 7: Scalar Operand Shift Instructions - Pseudo-instructions
+$pseudo_op rv64_p::psshl.ws sshl                  31=1 30..28=0x2 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
+$pseudo_op rv64_p::psshlr.ws sshlr                31=1 30..28=0x3 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 $pseudo_op rv64_p::pssha.ws ssha                  31=1 30..28=0x6 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 $pseudo_op rv64_p::psshar.ws sshar                31=1 30..28=0x7 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 
@@ -271,6 +273,11 @@ psll.dbs            31=0 30..28=0x0 27=1 26..25=0x2 rs2 p_rs1_p 15..12=0x6 p_rd_
 padd.dhs            31=0 30..28=0x1 27=1 26..25=0x0 rs2 p_rs1_p 15..12=0x6 p_rd_p 7..0=0x1b
 padd.dws            31=0 30..28=0x1 27=1 26..25=0x1 rs2 p_rs1_p 15..12=0x6 p_rd_p 7..0=0x1b
 padd.dbs            31=0 30..28=0x1 27=1 26..25=0x2 rs2 p_rs1_p 15..12=0x6 p_rd_p 7..0=0x1b
+
+psshl.dhs           31=0 30..28=0x2 27=1 26..25=0x0 rs2 p_rs1_p 15..12=0x6 p_rd_p 7..0=0x1b
+psshl.dws           31=0 30..28=0x2 27=1 26..25=0x1 rs2 p_rs1_p 15..12=0x6 p_rd_p 7..0=0x1b
+psshlr.dhs          31=0 30..28=0x3 27=1 26..25=0x0 rs2 p_rs1_p 15..12=0x6 p_rd_p 7..0=0x1b
+psshlr.dws          31=0 30..28=0x3 27=1 26..25=0x1 rs2 p_rs1_p 15..12=0x6 p_rd_p 7..0=0x1b
 
 pssha.dhs           31=0 30..28=0x6 27=1 26..25=0x0 rs2 p_rs1_p 15..12=0x6 p_rd_p 7..0=0x1b
 pssha.dws           31=0 30..28=0x6 27=1 26..25=0x1 rs2 p_rs1_p 15..12=0x6 p_rd_p 7..0=0x1b

--- a/extensions/unratified/rv64_p
+++ b/extensions/unratified/rv64_p
@@ -18,10 +18,14 @@ pli.w               31=1 30..28=0x3 27=0 26..25=0x1 p_imm10    14..12=0x2 rd 6..
 psll.ws             31=1 30..28=0x0 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 padd.ws             31=1 30..28=0x1 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 
+psshl.ws            31=1 30..28=0x2 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
+psshlr.ws           31=1 30..28=0x3 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 pssha.ws            31=1 30..28=0x6 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 sha                 31=1 30..28=0x6 27=1 26..25=0x3 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 psshar.ws           31=1 30..28=0x7 27=1 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 shar                31=1 30..28=0x7 27=1 26..25=0x3 rs2 rs1 14..12=0x2 rd 6..0=0x1b
+shl                 31=1 30..28=0x2 27=1 26..25=0x3 rs2 rs1 14..12=0x2 rd 6..0=0x1b
+shlr                31=1 30..28=0x3 27=1 26..25=0x3 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 
 
 # Page 6: Unary Instructions & PLUI (OP-IMM-32, funct3=010)
@@ -69,8 +73,17 @@ pmaccu.w.h01        31=1 30..27=0x7 26..25=0x1 rs2 rs1 14..12=0x1 rd 6..0=0x3b
 maccu.w01           31=1 30..27=0x7 26..25=0x3 rs2 rs1 14..12=0x1 rd 6..0=0x3b
 
 # Page 11: Shift-Add & ZIP/UNZIP Instructions (OP-32, funct3=010)
+pnclipup.b          31=1 30..28=0x0 27=0 26..25=0x0 rs2 rs1 14..12=0x2 rd 6..0=0x3b
+pnclipup.h          31=1 30..28=0x0 27=0 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x3b
+pnclipup.w          31=1 30..28=0x0 27=0 26..25=0x3 rs2 rs1 14..12=0x2 rd 6..0=0x3b
+
 psh1add.w           31=1 30..28=0x2 27=0 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x3b
 pssh1sadd.w         31=1 30..28=0x3 27=0 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x3b
+
+pnclipp.b           31=1 30..28=0x4 27=0 26..25=0x0 rs2 rs1 14..12=0x2 rd 6..0=0x3b
+pnclipp.h           31=1 30..28=0x4 27=0 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x3b
+pnclipp.w           31=1 30..28=0x4 27=0 26..25=0x3 rs2 rs1 14..12=0x2 rd 6..0=0x3b
+
 unzip8p             31=1 30..28=0x6 27=0 26..25=0x0 rs2 rs1 14..12=0x2 rd 6..0=0x3b
 unzip16p            31=1 30..28=0x6 27=0 26..25=0x1 rs2 rs1 14..12=0x2 rd 6..0=0x3b
 unzip8hp            31=1 30..28=0x6 27=0 26..25=0x2 rs2 rs1 14..12=0x2 rd 6..0=0x3b

--- a/extensions/unratified/rv_p
+++ b/extensions/unratified/rv_p
@@ -29,6 +29,8 @@ plui.h              31..27=0x1e 26..25=0x0 p_imm10 14..12=0x2 rd 6..0=0x1b
 # Page 7: Scalar Operand Shift/Add Instructions (OP-IMM-32, funct3=010)
 psll.hs             31=1 30..28=0x0 27=1 26..25=0x0 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 psll.bs             31=1 30..28=0x0 27=1 26..25=0x2 rs2 rs1 14..12=0x2 rd 6..0=0x1b
+psshl.hs            31=1 30..28=0x2 27=1 26..25=0x0 rs2 rs1 14..12=0x2 rd 6..0=0x1b
+psshlr.hs           31=1 30..28=0x3 27=1 26..25=0x0 rs2 rs1 14..12=0x2 rd 6..0=0x1b
 
 # Page 9: Packed Add/Sub Instructions (OP-32, funct3=000)
 padd.hs             31=1 30..28=0x1 27=1 26..25=0x0 rs2 rs1 14..12=0x2 rd 6..0=0x1b

--- a/src/riscv_opcodes/constants.py
+++ b/src/riscv_opcodes/constants.py
@@ -327,6 +327,8 @@ emitted_pseudo_ops = [
     "srari_rv32",
     "ssha",
     "sshar",
+    "sshl",
+    "sshlr",
     "sslai",
     "ssub",
     "ssubu",


### PR DESCRIPTION
Quoted from spec

"This version (020) differs from the previous one (019) with the addition of:
  * SHL instructions (shift left or right, logical) that are unsigned versions of the SHA instructions (shift left or right, arithmetic); and
  * for RV64 only, ‘P’-suffi x versions of PNCLIP instructions that are similar to RV32 PNCLIP instructions without shifting or rounding.

The complete set of instructions added for RV32 are:
  PSSHL.HS SSHL PSSHL.DHS PSSHL.DWS
  PSSHLR.HS SSHLR PSSHLR.DHS PSSHLR.DWS
And for RV64:
  PSSHL.HS PSSHL.WS SHL PNCLIPP.B PNCLIPP.H PNCLIPP.W
  PSSHLR.HS PSSHLR.WS SHLR PNCLIPUP.B PNCLIPUP.H PNCLIPUP.W"

reference:
  https://www.jhauser.us/RISCV/ext-P/RVP-instrEncodings-020.pdf