### PR TITLE
Allow overlapping extensions with `--warn-overlap`

### DIFF
--- a/src/riscv_opcodes/parse.py
+++ b/src/riscv_opcodes/parse.py
@@ -31,8 +31,9 @@ def generate_extensions(
     go: bool,
     latex: bool,
     svg: bool,
+    warn_overlap: bool = False,
 ):
-    instr_dict = create_inst_dict(extensions, include_pseudo)
+    instr_dict = create_inst_dict(extensions, include_pseudo, warn_overlap=warn_overlap)
     instr_dict = dict(sorted(instr_dict.items()))
     instr_dict_with_segment = add_segmented_vls_insn(instr_dict)
 
@@ -41,7 +42,7 @@ def generate_extensions(
 
     if c:
         instr_dict_c = create_inst_dict(
-            extensions, False, include_pseudo_ops=emitted_pseudo_ops
+            extensions, False, include_pseudo_ops=emitted_pseudo_ops, warn_overlap=warn_overlap
         )
         instr_dict_c = dict(sorted(instr_dict_c.items()))
         make_c(instr_dict_c)
@@ -98,6 +99,11 @@ def main():
     parser.add_argument("-latex", action="store_true", help="Generate output for Latex")
     parser.add_argument("-svg", action="store_true", help="Generate .svg output")
     parser.add_argument(
+        "--warn-overlap",
+        action="store_true",
+        help="Warn instead of error on overlapping instruction encodings",
+    )
+    parser.add_argument(
         "extensions",
         nargs="*",
         help="Extensions to use. This is a glob of the rv_.. files, e.g. 'rv*' will give all extensions.",
@@ -118,4 +124,5 @@ def main():
         args.go,
         args.latex,
         args.svg,
+        args.warn_overlap,
     )

--- a/src/riscv_opcodes/parse.py
+++ b/src/riscv_opcodes/parse.py
@@ -42,7 +42,10 @@ def generate_extensions(
 
     if c:
         instr_dict_c = create_inst_dict(
-            extensions, False, include_pseudo_ops=emitted_pseudo_ops, warn_overlap=warn_overlap
+            extensions,
+            False,
+            include_pseudo_ops=emitted_pseudo_ops,
+            warn_overlap=warn_overlap,
         )
         instr_dict_c = dict(sorted(instr_dict_c.items()))
         make_c(instr_dict_c)

--- a/src/riscv_opcodes/shared_utils.py
+++ b/src/riscv_opcodes/shared_utils.py
@@ -407,7 +407,7 @@ def read_lines(file: str) -> "list[str]":
 
 # Update the instruction dictionary
 def process_standard_instructions(
-    lines: "list[str]", instr_dict: InstrDict, file_name: str
+    lines: "list[str]", instr_dict: InstrDict, file_name: str, warn_overlap: bool = False
 ):
     """Processes standard instructions from the given lines and updates the instruction dictionary."""
     for line in lines:
@@ -437,9 +437,11 @@ def process_standard_instructions(
                     and not instruction_overlap_allowed(name, key)
                     and same_base_isa(ext_name, item["extension"])
                 ):
-                    log_and_exit(
-                        f'Instruction {name} in extension {ext_name} overlaps with {key} in {item["extension"]}'
-                    )
+                    overlap_msg = f'Instruction {name} in extension {ext_name} overlaps with {key} in {item["extension"]}'
+                    if warn_overlap:
+                        logging.warning(overlap_msg)
+                    else:
+                        log_and_exit(overlap_msg)
 
             instr_dict[name] = single_dict
 
@@ -543,6 +545,7 @@ def create_inst_dict(
     file_filter: "list[str]",
     include_pseudo: bool = False,
     include_pseudo_ops: "Optional[list[str]]" = None,
+    warn_overlap: bool = False,
 ) -> InstrDict:
     """
     Creates a dictionary of instructions based on the provided file filters.
@@ -607,7 +610,7 @@ def create_inst_dict(
     for file_name in file_names:
         logging.debug(f"Parsing File: {file_name} for standard instructions")
         lines = read_lines(file_name)
-        process_standard_instructions(lines, instr_dict, file_name)
+        process_standard_instructions(lines, instr_dict, file_name, warn_overlap)
 
     logging.debug("Collecting pseudo instructions")
     for file_name in file_names:

--- a/src/riscv_opcodes/shared_utils.py
+++ b/src/riscv_opcodes/shared_utils.py
@@ -407,7 +407,10 @@ def read_lines(file: str) -> "list[str]":
 
 # Update the instruction dictionary
 def process_standard_instructions(
-    lines: "list[str]", instr_dict: InstrDict, file_name: str, warn_overlap: bool = False
+    lines: "list[str]",
+    instr_dict: InstrDict,
+    file_name: str,
+    warn_overlap: bool = False,
 ):
     """Processes standard instructions from the given lines and updates the instruction dictionary."""
     for line in lines:


### PR DESCRIPTION
This PR loosens the behaviour of the parser in the presence of overlapping instruction. Instead of failing, if the `--warn-overlap` flag is passed, warnings are reported in the presence of instructions with overlapping encodings.

This feature is needed to e.g. generate a single `inst.sverilog` file with all instructions for a core that can support multiple custom ISA extensions (possibly overlapping) at configuration time.

This is the case for the Snitch core for example. Though overlapping ISA extensions cannot be simultaneously enabled, it can be configured to support different (overlapping) ISA extensions at configuration time.
This is currently achieved by generating a single `inst.sverilog` file, and using a single case statement to implement the decoder, with conditionals to select overlapping instructions, e.g.:
```systemverilog
unique casez (inst_data)
  P_SH_IRPOST,
  SCFGRI: begin
    if (Xpulppostmod) begin
      // Decode P_SH_IRPOST instruction in Xpulppostmod ISA extension
    end else if (Xssr) begin
      // Decode SCFGRI instruction in Xssr ISA extension
    end
  end
endcase
```