### PR TITLE
Fix instruction search paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ DEBUG::      Processing line: bne     bimm12hi rs1 rs2 bimm12lo 14..12=1 6..2=0x
 
 ## How do I find where an instruction is defined?
 
-You can use `grep "^\s*<instr-name>" rv* unratified/rv*` OR run `make` and open
+From the repository root, you can use `grep "^\s*<instr-name>" extensions/rv* extensions/unratified/rv*` OR run `make` and open
 `instr_dict.json` and search for the instruction you are looking for. Within
 that instruction the `extension` field will indicate which file the
 instruction was picked from.


### PR DESCRIPTION
Updates the README instruction search example to use the current extensions/ and extensions/unratified/ directories.

The previous example referenced rv* and unratified/rv* from the repository root, but the documented project structure places opcode files under extensions/.