### PR TITLE
Fix names of dot-product instructions and extensions

### DIFF
--- a/extensions/unratified/rv_zvfbdot32f
+++ b/extensions/unratified/rv_zvfbdot32f
@@ -1,1 +1,0 @@
-vfbdot.vv      31..26=0x2b vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvfbdota32f
+++ b/extensions/unratified/rv_zvfbdota32f
@@ -1,0 +1,1 @@
+vfbdota.vv     31..26=0x2b vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvfqbdot8f
+++ b/extensions/unratified/rv_zvfqbdot8f
@@ -1,2 +1,0 @@
-vfqbdot.vv     31..26=0x2e vm vs2 vs1 14..12=1 vd 6..0=0x77
-vfqbdot.alt.vv 31..26=0x2f vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvfqldot8f
+++ b/extensions/unratified/rv_zvfqldot8f
@@ -1,2 +1,0 @@
-vfqldot.vv     31..26=0x26 vm vs2 vs1 14..12=1 vd 6..0=0x77
-vfqldot.alt.vv 31..26=0x27 vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvfqwbdota8f
+++ b/extensions/unratified/rv_zvfqwbdota8f
@@ -1,0 +1,2 @@
+vfqwbdota.vv     31..26=0x2e vm vs2 vs1 14..12=1 vd 6..0=0x77
+vfqwbdota.alt.vv 31..26=0x2f vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvfqwdota8f
+++ b/extensions/unratified/rv_zvfqwdota8f
@@ -1,0 +1,2 @@
+vfqwdota.vv     31..26=0x26 vm vs2 vs1 14..12=1 vd 6..0=0x77
+vfqwdota.alt.vv 31..26=0x27 vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvfwbdot16bf
+++ b/extensions/unratified/rv_zvfwbdot16bf
@@ -1,1 +1,0 @@
-vfwbdot.vv     31..26=0x2c vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvfwbdota16bf
+++ b/extensions/unratified/rv_zvfwbdota16bf
@@ -1,0 +1,1 @@
+vfwbdota.vv    31..26=0x2c vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvfwdota16bf
+++ b/extensions/unratified/rv_zvfwdota16bf
@@ -1,0 +1,1 @@
+vfwdota.vv     31..26=0x24 vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvfwldot16bf
+++ b/extensions/unratified/rv_zvfwldot16bf
@@ -1,1 +1,0 @@
-vfwldot.vv     31..26=0x24 vm vs2 vs1 14..12=1 vd 6..0=0x77

--- a/extensions/unratified/rv_zvqbdot8i
+++ b/extensions/unratified/rv_zvqbdot8i
@@ -1,2 +1,0 @@
-vqbdotu.vv     31..26=0x2e vm vs2 vs1 14..12=0 vd 6..0=0x77
-vqbdots.vv     31..26=0x2f vm vs2 vs1 14..12=0 vd 6..0=0x77

--- a/extensions/unratified/rv_zvqldot8i
+++ b/extensions/unratified/rv_zvqldot8i
@@ -1,2 +1,0 @@
-vqldotu.vv     31..26=0x26 vm vs2 vs1 14..12=0 vd 6..0=0x77
-vqldots.vv     31..26=0x27 vm vs2 vs1 14..12=0 vd 6..0=0x77

--- a/extensions/unratified/rv_zvqwbdota8i
+++ b/extensions/unratified/rv_zvqwbdota8i
@@ -1,0 +1,2 @@
+vqwbdotau.vv   31..26=0x2e vm vs2 vs1 14..12=0 vd 6..0=0x77
+vqwbdotas.vv   31..26=0x2f vm vs2 vs1 14..12=0 vd 6..0=0x77

--- a/extensions/unratified/rv_zvqwdota8i
+++ b/extensions/unratified/rv_zvqwdota8i
@@ -1,0 +1,2 @@
+vqwdotau.vv    31..26=0x26 vm vs2 vs1 14..12=0 vd 6..0=0x77
+vqwdotas.vv    31..26=0x27 vm vs2 vs1 14..12=0 vd 6..0=0x77


### PR DESCRIPTION
In accordance with https://github.com/riscv/riscv-isa-manual/pull/2618