### PR TITLE
Add Zilx indexed integer load instruction encodings

### DIFF
--- a/extensions/unratified/rv64_zilx
+++ b/extensions/unratified/rv64_zilx
@@ -1,0 +1,25 @@
+# rv64_zilx
+# Zilx indexed integer load instructions available only on RV64:
+#   - doubleword loads (funct3=011)
+#   - unsigned-word loads (funct3=110)
+#   - the scaled unsigned-word-index mode (funct5=11110), which zero-extends
+#     X[rs1][31:0] to 64 bits before scaling
+# See rv_zilx for the shared encoding layout.
+
+# Unscaled indexed loads, RV64-only widths (funct5=10010)
+lxwu    rd rs1 rs2 31..27=0x12 26..25=0 14..12=6 6..2=0x0B 1..0=3
+lxd     rd rs1 rs2 31..27=0x12 26..25=0 14..12=3 6..2=0x0B 1..0=3
+
+# Scaled indexed loads, RV64-only widths (funct5=11010)
+lxswu   rd rs1 rs2 31..27=0x1A 26..25=0 14..12=6 6..2=0x0B 1..0=3
+lxsd    rd rs1 rs2 31..27=0x1A 26..25=0 14..12=3 6..2=0x0B 1..0=3
+
+# Scaled indexed loads with zero-extended 32-bit index (funct5=11110),
+# EA = X[rs2] + (zext32(X[rs1]) << log2(size)); RV64-only
+lxsuwb  rd rs1 rs2 31..27=0x1E 26..25=0 14..12=0 6..2=0x0B 1..0=3
+lxsuwbu rd rs1 rs2 31..27=0x1E 26..25=0 14..12=4 6..2=0x0B 1..0=3
+lxsuwh  rd rs1 rs2 31..27=0x1E 26..25=0 14..12=1 6..2=0x0B 1..0=3
+lxsuwhu rd rs1 rs2 31..27=0x1E 26..25=0 14..12=5 6..2=0x0B 1..0=3
+lxsuww  rd rs1 rs2 31..27=0x1E 26..25=0 14..12=2 6..2=0x0B 1..0=3
+lxsuwwu rd rs1 rs2 31..27=0x1E 26..25=0 14..12=6 6..2=0x0B 1..0=3
+lxsuwd  rd rs1 rs2 31..27=0x1E 26..25=0 14..12=3 6..2=0x0B 1..0=3

--- a/extensions/unratified/rv_zilx
+++ b/extensions/unratified/rv_zilx
@@ -1,0 +1,26 @@
+# rv_zilx
+# Zilx indexed integer load instructions (Version 0.1).
+# Zilx reuses the AMO major opcode (0101111). rs1 is the index operand and
+# rs2 is the base operand. funct3 encodes the base-load width/signedness and
+# funct5 encodes the addressing mode; aq and rl must both be 0.
+# Encoding layout:
+#   [31:27]=funct5  [26]=aq(0)  [25]=rl(0)  [24:20]=rs2(base)
+#   [19:15]=rs1(index)  [14:12]=funct3  [11:7]=rd  [6:0]=AMO(0101111)
+# funct5 : 10010=unscaled(lx) 11010=scaled(lxs) 11110=scaled uw-index(lxsuw)
+# This file holds the forms available on both RV32 and RV64.
+
+# Unscaled indexed loads (funct5=10010, EA = X[rs2] + X[rs1])
+lxh   rd rs1 rs2 31..27=0x12 26..25=0 14..12=1 6..2=0x0B 1..0=3
+lxhu  rd rs1 rs2 31..27=0x12 26..25=0 14..12=5 6..2=0x0B 1..0=3
+lxw   rd rs1 rs2 31..27=0x12 26..25=0 14..12=2 6..2=0x0B 1..0=3
+
+# Scaled indexed loads (funct5=11010, EA = X[rs2] + (X[rs1] << log2(size)))
+lxsb  rd rs1 rs2 31..27=0x1A 26..25=0 14..12=0 6..2=0x0B 1..0=3
+lxsbu rd rs1 rs2 31..27=0x1A 26..25=0 14..12=4 6..2=0x0B 1..0=3
+lxsh  rd rs1 rs2 31..27=0x1A 26..25=0 14..12=1 6..2=0x0B 1..0=3
+lxshu rd rs1 rs2 31..27=0x1A 26..25=0 14..12=5 6..2=0x0B 1..0=3
+lxsw  rd rs1 rs2 31..27=0x1A 26..25=0 14..12=2 6..2=0x0B 1..0=3
+
+# lxb/lxbu are assembler pseudoinstructions for the scaled byte loads
+$pseudo_op rv_zilx::lxsb  lxb  rd rs1 rs2 31..27=0x1A 26..25=0 14..12=0 6..2=0x0B 1..0=3
+$pseudo_op rv_zilx::lxsbu lxbu rd rs1 rs2 31..27=0x1A 26..25=0 14..12=4 6..2=0x0B 1..0=3


### PR DESCRIPTION
Add the `Zilx` family of indexed integer load instructions (v0.1), which reuse the AMO major opcode in an R-type form where rs1 is the index and rs2 is the base. funct5 selects the addressing mode (unscaled, scaled, or scaled with a zero-extended 32-bit index) and funct3 reuses the base integer load width/signedness encoding, with `aq` and `rl` held at 0.

Shared RV32/RV64 forms (`lxh/lxw/lxhu`, the scaled `lxs*` loads, and the `lxb/lxbu` pseudoinstructions for the scaled byte loads) live in `rv_zilx`. RV64-only forms live in `rv64_zilx`: the doubleword and unsigned-word loads plus the scaled unsigned-word-index (`lxsuw*`) mode.

Doc: https://github.com/riscv/riscv-zilx/blob/main/src/unpriv/zilx.adoc