### PR TITLE
Fix neg pseudo-op to use rs2 instead of rs1

### DIFF
--- a/extensions/rv_i
+++ b/extensions/rv_i
@@ -48,7 +48,7 @@ $pseudo_op rv_i::ebreak sbreak    11..7=0 19..15=0 31..20=0x001 14..12=0 6..2=0x
 
 #pseudoinstructions from asm manual
 $pseudo_op rv_i::addi   mv rd rs1 31..20=0 14..12=0 6..2=0x04 1..0=3
-$pseudo_op rv_i::sub    neg rd rs1 31..25=32 24..20=0x0 14..12=0 6..2=0x0C 1..0=3
+$pseudo_op rv_i::sub    neg rd rs2 31..25=32 19..15=0x0 14..12=0 6..2=0x0C 1..0=3
 $pseudo_op rv_i::addi   nop 31..20=0 19..15=0 14..12=0 11..7=0 6..2=0x04 1..0=3
 $pseudo_op rv_i::andi   zext.b rd rs1 31..20=0xff 14..12=7 6..2=0x04 1..0=3
 


### PR DESCRIPTION
Currently, the neg pseudo-op in rv_i hardcodes rs2 to zero, which expands to sub rd, rs1, x0 (computing rd = rs1 - 0).

This PR fixes the hardware mapping by accepting rs2 from the user and hardcoding rs1 to zero. This correctly expands to sub rd, x0, rs2 (computing rd = 0 - rs2).